### PR TITLE
chore: CI/CD dev 워크플로우 copy 명령어 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -2,7 +2,7 @@ name: cd dev
 
 on:
   pull_request:
-    branches: [ "develop", "main" ]
+    branches: [ "develop" ]
     types: [closed]
 
 jobs:
@@ -37,8 +37,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Set application.yml
-        run: ./gradlew copyYML
+      - name: Copy application.yml
+        run: cp ./server-config/*.yml ./src/main/resources/
         
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-    - name: Set application.yml
-      run: ./gradlew copyYML
+    - name: Copy application.yml
+      run: cp ./server-config/*.yml ./src/main/resources/
       
     - name: Test with Gradle
       run: ./gradlew test

--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,6 @@ repositories {
     mavenCentral()
 }
 
-task copyYML(type: Copy){
-    copy {
-        from './server-config'
-        include "*.yml"
-        into './src/main/resources'
-    }
-}
-
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'


### PR DESCRIPTION
## 🚀 작업 내용 설명
- build.gradle, task 제거
- CI, copy 명령어 수정
- CD, 브랜치 main 제거 및 copy 명령어 수정

## 📢 그 외
- 단순 copy 명령어를 처리하는데 gradlew로 실행할 필요가 없다고 판단하여 수정

## 📌 관련 이슈
- fork 레포지토리에서 PR 요청시 토큰 권한 오류가 발생하여 아래 PR로 이동
- #11 