### PR TITLE
Docs/rest docs posts

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -29,7 +29,7 @@ HTTP 상태 코드 본 REST API에서 사용하는 HTTP 상태 코드는 가능�
 | `400 Bad Request`| 잘못된 요청을 보낸 경우. 응답 본문에 더 오류에 대한 정보가 담겨있음
 | `401 Unauthorization`| 인증에 실패한 경우. 응답 본문에 더 오류에 대한 정보가 담겨있음
 | `404 Not Found`| 요청한 리소스가 없음.
-| `500 Internal Server Error`| 서버 내부 요류가 발생한 경우.
+| `500 Internal Server Error`| 서버 내부 오류가 발생한 경우.
 
 |===
 

--- a/src/docs/asciidoc/posts.adoc
+++ b/src/docs/asciidoc/posts.adoc
@@ -4,7 +4,7 @@
 [[게시글-작성]]
 === 게시글 작성
 
-operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-fields,http-response']
+operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-parts,http-response']
 
 [[게시글-상세-조회]]
 === 게시글 상세 조회

--- a/src/docs/asciidoc/posts.adoc
+++ b/src/docs/asciidoc/posts.adoc
@@ -4,7 +4,7 @@
 [[게시글-작성]]
 === 게시글 작성
 
-operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-parts,http-response']
+operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게시글-상세-조회]]
 === 게시글 상세 조회

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -3,22 +3,16 @@ package com.swyp8team2.post.presentation;
 import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
 import com.swyp8team2.post.presentation.dto.AuthorDto;
-import com.swyp8team2.post.presentation.dto.CreatePostRequest;
 import com.swyp8team2.post.presentation.dto.PostResponse;
 import com.swyp8team2.post.presentation.dto.SimplePostResponse;
 import com.swyp8team2.post.presentation.dto.VoteResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,9 +22,10 @@ import java.util.List;
 @RequestMapping("/posts")
 public class PostController {
 
-    @PostMapping("")
+    @PostMapping(value ="", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> createPost(
-            @Valid @RequestBody CreatePostRequest request,
+            @Valid @RequestPart("description") String description,
+            @Valid @RequestPart("files") List<MultipartFile> files,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
         return ResponseEntity.ok().build();
@@ -43,12 +38,12 @@ public class PostController {
                 new AuthorDto(
                         1L,
                         "author",
-                        "https://image.com/profile-image"
+                        "https://image.photopic.site/imagePath/profile-image"
                 ),
                 "description",
                 List.of(
-                        new VoteResponseDto(1L, "https://image.com/1", 62.75, true),
-                        new VoteResponseDto(2L, "https://image.com/2", 37.25, false)
+                        new VoteResponseDto(1L, "https://image.photopic.site/imagePath/1", 62.75, true),
+                        new VoteResponseDto(2L, "https://image.photopic.site/imagePath/2", 37.25, false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)
@@ -75,7 +70,7 @@ public class PostController {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.com/1",
+                                "https://image.photopic.site/imagePath/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )
@@ -95,7 +90,7 @@ public class PostController {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.com/1",
+                                "https://image.photopic.site/imagePath/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -3,16 +3,22 @@ package com.swyp8team2.post.presentation;
 import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
 import com.swyp8team2.post.presentation.dto.AuthorDto;
+import com.swyp8team2.post.presentation.dto.CreatePostRequest;
 import com.swyp8team2.post.presentation.dto.PostResponse;
 import com.swyp8team2.post.presentation.dto.SimplePostResponse;
 import com.swyp8team2.post.presentation.dto.VoteResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -22,10 +28,9 @@ import java.util.List;
 @RequestMapping("/posts")
 public class PostController {
 
-    @PostMapping(value ="", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping("")
     public ResponseEntity<Void> createPost(
-            @Valid @RequestPart("description") String description,
-            @Valid @RequestPart("files") List<MultipartFile> files,
+            @Valid @RequestBody CreatePostRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
         return ResponseEntity.ok().build();
@@ -38,12 +43,12 @@ public class PostController {
                 new AuthorDto(
                         1L,
                         "author",
-                        "https://image.photopic.site/imagePath/profile-image"
+                        "https://image.photopic.site/profile-image"
                 ),
                 "description",
                 List.of(
-                        new VoteResponseDto(1L, "https://image.photopic.site/imagePath/1", 62.75, true),
-                        new VoteResponseDto(2L, "https://image.photopic.site/imagePath/2", 37.25, false)
+                        new VoteResponseDto(1L, "https://image.photopic.site/1", 62.75, true),
+                        new VoteResponseDto(2L, "https://image.photopic.site/2", 37.25, false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)
@@ -70,7 +75,7 @@ public class PostController {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.photopic.site/imagePath/1",
+                                "https://image.photopic.site/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )
@@ -90,7 +95,7 @@ public class PostController {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.photopic.site/imagePath/1",
+                                "https://image.photopic.site/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )

--- a/src/main/java/com/swyp8team2/post/presentation/dto/VoteRequestDto.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/VoteRequestDto.java
@@ -1,9 +1,9 @@
 package com.swyp8team2.post.presentation.dto;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record VoteRequestDto(
-        @NotEmpty
-        String imageUrl
+        @NotNull
+        Long imageFileId
 ) {
 }

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -2,8 +2,10 @@ package com.swyp8team2.post.presentation;
 
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
 import com.swyp8team2.post.presentation.dto.AuthorDto;
+import com.swyp8team2.post.presentation.dto.CreatePostRequest;
 import com.swyp8team2.post.presentation.dto.PostResponse;
 import com.swyp8team2.post.presentation.dto.SimplePostResponse;
+import com.swyp8team2.post.presentation.dto.VoteRequestDto;
 import com.swyp8team2.post.presentation.dto.VoteResponseDto;
 import com.swyp8team2.support.RestDocsTest;
 import com.swyp8team2.support.WithMockUserInfo;
@@ -11,22 +13,22 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -37,46 +39,32 @@ class PostControllerTest extends RestDocsTest {
     @DisplayName("게시글 생성")
     void createPost() throws Exception {
         //given
-        MockMultipartFile description = new MockMultipartFile(
-                "description",
-                null,
-                null,
-                "게시물 설명".getBytes(StandardCharsets.UTF_8)
-        );
-        MockMultipartFile file1 = new MockMultipartFile(
-                "files",
-                "image.jpg",
-                MediaType.IMAGE_JPEG_VALUE,
-                "".getBytes(StandardCharsets.UTF_8)
-        );
-        MockMultipartFile file2 = new MockMultipartFile(
-                "files",
-                "image.png",
-                MediaType.IMAGE_PNG_VALUE,
-                "".getBytes(StandardCharsets.UTF_8)
+        CreatePostRequest request = new CreatePostRequest(
+                "제목",
+                List.of(new VoteRequestDto(1L), new VoteRequestDto(2L))
         );
 
         //when then
-        mockMvc.perform(MockMvcRequestBuilders.multipart("/posts")
-                        .file(description)
-                        .file(file1)
-                        .file(file2)
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
                         .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                         requestHeaders(authorizationHeader()),
-                        requestParts(
-                                partWithName("description")
+                        requestFields(
+                                fieldWithPath("description")
+                                        .type(JsonFieldType.STRING)
                                         .description("설명")
-                                        .attributes(key("type").value("String"))
                                         .attributes(constraints("1~200자 사이")),
-                                partWithName("files")
-                                        .description("투표 후보 이미지 파일")
-                                        .attributes(key("type").value("Array[File]"))
-                                        .attributes(constraints("최소 2개"))
-                        )
-                ));
+                                fieldWithPath("votes")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("투표 후보")
+                                        .attributes(constraints("최소 2개")),
+                                fieldWithPath("votes[].imageFileId")
+                                        .type(JsonFieldType.NUMBER)
+                                        .description("투표 후보 이미지 ID")
+                        )));
     }
 
     @Test
@@ -89,12 +77,12 @@ class PostControllerTest extends RestDocsTest {
                 new AuthorDto(
                         1L,
                         "author",
-                        "https://image.photopic.site/imagePath/profile-image"
+                        "https://image.photopic.site/profile-image"
                 ),
                 "description",
                 List.of(
-                        new VoteResponseDto(1L, "https://image.photopic.site/imagePath/1", 62.75, true),
-                        new VoteResponseDto(2L, "https://image.photopic.site/imagePath/2", 37.25, false)
+                        new VoteResponseDto(1L, "https://image.photopic.site/1", 62.75, true),
+                        new VoteResponseDto(2L, "https://image.photopic.site/2", 37.25, false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)
@@ -155,7 +143,7 @@ class PostControllerTest extends RestDocsTest {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.photopic.site/imagePath/1",
+                                "https://image.photopic.site/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )
@@ -208,7 +196,7 @@ class PostControllerTest extends RestDocsTest {
                 List.of(
                         new SimplePostResponse(
                                 1L,
-                                "https://image.photopic.site/imagePath/1",
+                                "https://image.photopic.site/1",
                                 "https://photopic.site/shareurl",
                                 LocalDateTime.of(2025, 2, 13, 12, 0)
                         )

--- a/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
@@ -1,0 +1,21 @@
+|===
+|필드명|타입|필수값|조건|설명
+
+{{#requestParts}}
+    |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/requestParts}}
+{{#requestPartFields}}
+    |{{#fields}}
+        |{{path}}
+        |{{description}}
+        |{{type}}
+        |{{optional}}
+        |{{#constraints}}{{.}}{{/constraints}}
+    {{/fields}}
+{{/requestPartFields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-parts.snippet
@@ -8,14 +8,5 @@
     |{{#tableCellContent}}{{#constraints}}{{.}}{{/constraints}}{{/tableCellContent}}
     |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 {{/requestParts}}
-{{#requestPartFields}}
-    |{{#fields}}
-        |{{path}}
-        |{{description}}
-        |{{type}}
-        |{{optional}}
-        |{{#constraints}}{{.}}{{/constraints}}
-    {{/fields}}
-{{/requestPartFields}}
 
 |===


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 개요 오타 수정 (요류가 -> 오류가)
- 이미지 URL 수정 (image.com -> image.photopic.site)
- 게시물 생성 시 파라미터 수정
  - PostController.createPost(`@RequestBody` -> `@RequestPart`)
  - CreatePostRequest -> String, List<MultipartFile>
  - Rest Docs 형식 수정 (Request Fiels -> Request Parts)

## 📢 그 외
- 프론트에서 multiple로 파일을 받을 때 `@RequestBody`로 받을 수가 없는 것 같습니다
- 따라서 `@RequestPart`를 사용했는데 이 때, 파일을 `List<MultipartFile>`로 분리하고
  description(String) 하나만 남게 되어서 CreatePostRequest 객체가 필요한지 고민이 됩니다
  의견 부탁드립니다

## 📌 관련 이슈
#13 
