### PR TITLE
게시글 생성 기능 추가

### DIFF
--- a/src/docs/asciidoc/comments.adoc
+++ b/src/docs/asciidoc/comments.adoc
@@ -2,16 +2,16 @@
 == 댓글 API
 
 [[댓글-생성]]
-=== 댓글 생성
+=== 댓글 생성 (미구현)
 
 operation::comment-controller-test/create-comment[snippets='http-request,curl-request,path-parameters,request-headers,request-fields,http-response']
 
 [[댓글-조회]]
-=== 댓글 조회
+=== 댓글 조회 (미구현)
 
 operation::comment-controller-test/find-comments[snippets='http-request,curl-request,path-parameters,http-response,response-fields']
 
 [[댓글-삭제]]
-=== 댓글 삭제
+=== 댓글 삭제 (미구현)
 
 operation::comment-controller-test/delete-comment[snippets='http-request,curl-request,path-parameters,request-headers,http-response']

--- a/src/docs/asciidoc/posts.adoc
+++ b/src/docs/asciidoc/posts.adoc
@@ -7,21 +7,21 @@
 operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게시글-상세-조회]]
-=== 게시글 상세 조회
+=== 게시글 상세 조회 (미구현)
 
 operation::post-controller-test/find-post[snippets='http-request,curl-request,path-parameters,http-response,response-fields']
 
 [[내가-작성한-게시글-조회]]
-=== 내가 작성한 게시글 조회
+=== 내가 작성한 게시글 조회 (미구현)
 
 operation::post-controller-test/find-my-post[snippets='http-request,curl-request,query-parameters,request-headers,http-response,response-fields']
 
 [[내가-참여한-게시글-조회]]
-=== 내가 참여한 게시글 조회
+=== 내가 참여한 게시글 조회 (미구현)
 
 operation::post-controller-test/find-voted-post[snippets='http-request,curl-request,query-parameters,request-headers,http-response,response-fields']
 
 [[게시글-삭제]]
-=== 게시글 삭제
+=== 게시글 삭제 (미구현)
 
 operation::post-controller-test/delete-post[snippets='http-request,curl-request,path-parameters,request-headers,http-response']

--- a/src/docs/asciidoc/users.adoc
+++ b/src/docs/asciidoc/users.adoc
@@ -2,6 +2,6 @@
 == 유저 API
 
 [[유저-정보-조회]]
-=== 유저 정보 조회
+=== 유저 정보 조회 (미구현)
 
 operation::user-controller-test/find-user-info[snippets='http-request,curl-request,path-parameters,http-response,response-fields']

--- a/src/docs/asciidoc/votes.adoc
+++ b/src/docs/asciidoc/votes.adoc
@@ -2,21 +2,21 @@
 == 투표 API
 
 [[투표]]
-=== 투표
+=== 투표 (미구현)
 
 operation::vote-controller-test/vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게스트-투표]]
-=== 게스트 투표
+=== 게스트 투표 (미구현)
 
 operation::vote-controller-test/guest-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[투표-변경]]
-=== 투표 변경
+=== 투표 변경 (미구현)
 
 operation::vote-controller-test/change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게스트-투표-변경]]
-=== 게스트 투표 변경
+=== 게스트 투표 변경 (미구현)
 
 operation::vote-controller-test/guest-change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']

--- a/src/main/java/com/swyp8team2/auth/application/AuthService.java
+++ b/src/main/java/com/swyp8team2/auth/application/AuthService.java
@@ -10,6 +10,7 @@ import com.swyp8team2.auth.domain.SocialAccountRepository;
 import com.swyp8team2.user.application.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +25,7 @@ public class AuthService {
         return oAuthService.getOAuthAuthorizationUrl();
     }
 
+    @Transactional
     public TokenPair oauthSignIn(String code) {
         OAuthUserInfo oAuthUserInfo = oAuthService.getUserInfo(code);
         SocialAccount socialAccount = socialAccountRepository.findBySocialIdAndProvider(

--- a/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
     MISSING_FILE_EXTENSION("확장자가 누락됨"),
     UNSUPPORTED_FILE_EXTENSION("지원하지 않는 확장자"),
     EXCEED_MAX_FILE_SIZE("파일 크기 초과"),
+    POST_NOT_FOUND("존재하지 않는 게시글"),
+    DESCRIPTION_LENGTH_EXCEEDED("게시글 설명 길이 초과"),
+    INVALID_POST_IMAGE_COUNT("게시글 이미지 개수 오류"),
 
     //401
     EXPIRED_TOKEN("토큰 만료"),
@@ -26,9 +29,11 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("서버 내부 오류"),
     INVALID_INPUT_VALUE("잘못된 입력 값"),
     SOCIAL_AUTHENTICATION_FAILED("소셜 로그인 실패"),
+    POST_IMAGE_NAME_GENERATOR_INDEX_OUT_OF_BOUND("이미지 이름 생성기 인덱스 초과"),
 
     //503
-    SERVICE_UNAVAILABLE("서비스 이용 불가");
+    SERVICE_UNAVAILABLE("서비스 이용 불가"),
+    ;
 
     private final String message;
 }

--- a/src/main/java/com/swyp8team2/post/application/PostImageNameGenerator.java
+++ b/src/main/java/com/swyp8team2/post/application/PostImageNameGenerator.java
@@ -1,0 +1,21 @@
+package com.swyp8team2.post.application;
+
+import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.common.exception.InternalServerException;
+
+public class PostImageNameGenerator {
+
+    private int index = 0;
+    private final String[] alphabets = new String[]{
+            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
+            "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T",
+            "U", "V", "W", "X", "Y", "Z"
+    };
+
+    public String generate() {
+        if (index >= alphabets.length) {
+            throw new InternalServerException(ErrorCode.POST_IMAGE_NAME_GENERATOR_INDEX_OUT_OF_BOUND);
+        }
+        return "뽀또" + alphabets[index++];
+    }
+}

--- a/src/main/java/com/swyp8team2/post/application/PostService.java
+++ b/src/main/java/com/swyp8team2/post/application/PostService.java
@@ -1,0 +1,38 @@
+package com.swyp8team2.post.application;
+
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.post.domain.PostImage;
+import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.post.presentation.dto.CreatePostRequest;
+import com.swyp8team2.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long create(Long userId, CreatePostRequest request) {
+        List<PostImage> postImages = createPostImages(request);
+        Post post = Post.create(userId, request.description(), postImages, "TODO: location");
+        Post save = postRepository.save(post);
+        return save.getId();
+    }
+
+    private List<PostImage> createPostImages(CreatePostRequest request) {
+        PostImageNameGenerator nameGenerator = new PostImageNameGenerator();
+        return request.votes().stream()
+                .map(voteRequestDto -> PostImage.create(
+                        nameGenerator.generate(),
+                        voteRequestDto.imageFileId()
+                )).toList();
+    }
+}

--- a/src/main/java/com/swyp8team2/post/domain/Post.java
+++ b/src/main/java/com/swyp8team2/post/domain/Post.java
@@ -1,0 +1,73 @@
+package com.swyp8team2.post.domain;
+
+import com.swyp8team2.common.domain.BaseEntity;
+import com.swyp8team2.common.exception.BadRequestException;
+import com.swyp8team2.common.exception.ErrorCode;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.swyp8team2.common.util.Validator.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String description;
+
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    private State state;
+
+    @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<PostImage> images = new ArrayList<>();
+
+    private String shareUrl;
+
+    public Post(Long id, Long userId, String description, State state, List<PostImage> images, String shareUrl) {
+        validateNull(userId, state, description, images);
+        validateEmptyString(shareUrl);
+        validateDescription(description);
+        validatePostImages(images);
+        this.id = id;
+        this.description = description;
+        this.userId = userId;
+        this.state = state;
+        this.images = images;
+        images.forEach(image -> image.setPost(this));
+        this.shareUrl = shareUrl;
+    }
+
+    private void validatePostImages(List<PostImage> images) {
+        if (images.size() < 2) {
+            throw new BadRequestException(ErrorCode.INVALID_POST_IMAGE_COUNT);
+        }
+    }
+
+    private void validateDescription(String description) {
+        if (description.length() > 100) {
+            throw new BadRequestException(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED);
+        }
+    }
+
+    public static Post create(Long userId, String description, List<PostImage> images, String shareUrl) {
+        return new Post(null, userId, description, State.PROGRESS, images, shareUrl);
+    }
+}

--- a/src/main/java/com/swyp8team2/post/domain/PostImage.java
+++ b/src/main/java/com/swyp8team2/post/domain/PostImage.java
@@ -1,0 +1,60 @@
+package com.swyp8team2.post.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.swyp8team2.common.util.Validator.validateEmptyString;
+import static com.swyp8team2.common.util.Validator.validateNull;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    private String name;
+
+    private Long imageFileId;
+
+    private int voteCount;
+
+    public PostImage(Long id, Post post, String name, Long imageFileId, int voteCount) {
+        validateNull(post, imageFileId);
+        validateEmptyString(name);
+        this.id = id;
+        this.post = post;
+        this.name = name;
+        this.imageFileId = imageFileId;
+        this.voteCount = voteCount;
+    }
+
+    public PostImage(String name, Long imageFileId, int voteCount) {
+        validateNull(imageFileId);
+        validateEmptyString(name);
+        this.name = name;
+        this.imageFileId = imageFileId;
+        this.voteCount = voteCount;
+    }
+
+    public static PostImage create(String name, Long imageFileId) {
+        return new PostImage(name, imageFileId, 0);
+    }
+
+    public void setPost(Post post) {
+        validateNull(post);
+        this.post = post;
+    }
+}

--- a/src/main/java/com/swyp8team2/post/domain/PostRepository.java
+++ b/src/main/java/com/swyp8team2/post/domain/PostRepository.java
@@ -1,0 +1,8 @@
+package com.swyp8team2.post.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/swyp8team2/post/domain/State.java
+++ b/src/main/java/com/swyp8team2/post/domain/State.java
@@ -1,0 +1,5 @@
+package com.swyp8team2.post.domain;
+
+public enum State {
+    PROGRESS, CLOSED
+}

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -2,6 +2,7 @@ package com.swyp8team2.post.presentation;
 
 import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
+import com.swyp8team2.post.application.PostService;
 import com.swyp8team2.post.presentation.dto.AuthorDto;
 import com.swyp8team2.post.presentation.dto.CreatePostRequest;
 import com.swyp8team2.post.presentation.dto.PostResponse;
@@ -28,11 +29,14 @@ import java.util.List;
 @RequestMapping("/posts")
 public class PostController {
 
+    private final PostService postService;
+
     @PostMapping("")
     public ResponseEntity<Void> createPost(
             @Valid @RequestBody CreatePostRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
+        postService.create(userInfo.userId(), request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/swyp8team2/post/presentation/dto/CreatePostRequest.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/CreatePostRequest.java
@@ -7,10 +7,10 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record CreatePostRequest(
-        @Size(min = 1, max = 200)
+        @NotNull
         String description,
 
-        @Valid @NotNull @Size(min = 2)
+        @Valid @NotNull
         List<VoteRequestDto> votes
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,18 @@
+server:
+  port: 8080
 
+---
+
+spring:
+  config:
+    import: classpath:application-dev.yml
+    activate:
+      on-profile: dev
+
+---
+
+spring:
+  config:
+    import: classpath:application-prod.yml
+    activate:
+      on-profile: prod

--- a/src/test/java/com/swyp8team2/post/application/PostImageNameGeneratorTest.java
+++ b/src/test/java/com/swyp8team2/post/application/PostImageNameGeneratorTest.java
@@ -1,0 +1,32 @@
+package com.swyp8team2.post.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostImageNameGeneratorTest {
+
+    PostImageNameGenerator postImageNameGenerator;
+
+    @BeforeEach
+    void setUp() {
+        postImageNameGenerator = new PostImageNameGenerator();
+    }
+
+    @Test
+    @DisplayName("이미지 이름 생성")
+    void generate() throws Exception {
+        //given
+
+        //when
+        String generate1 = postImageNameGenerator.generate();
+        String generate2 = postImageNameGenerator.generate();
+
+        //then
+        assertThat(generate1).isEqualTo("뽀또A");
+        assertThat(generate2).isEqualTo("뽀또B");
+    }
+}

--- a/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
+++ b/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
@@ -1,0 +1,88 @@
+package com.swyp8team2.post.application;
+
+import com.swyp8team2.common.exception.BadRequestException;
+import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.post.domain.PostImage;
+import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.post.presentation.dto.CreatePostRequest;
+import com.swyp8team2.post.presentation.dto.VoteRequestDto;
+import com.swyp8team2.support.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostServiceTest extends IntegrationTest {
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    @DisplayName("게시글 작성")
+    void create() throws Exception {
+        //given
+        long userId = 1L;
+        CreatePostRequest request = new CreatePostRequest("description", List.of(
+                new VoteRequestDto(1L),
+                new VoteRequestDto(2L)
+        ));
+
+        //when
+        Long postId = postService.create(userId, request);
+
+        //then
+        Post post = postRepository.findById(postId).get();
+        List<PostImage> images = post.getImages();
+        assertAll(
+                () -> assertThat(post.getDescription()).isEqualTo("description"),
+                () -> assertThat(post.getUserId()).isEqualTo(userId),
+                () -> assertThat(images).hasSize(2),
+                () -> assertThat(images.get(0).getImageFileId()).isEqualTo(1L),
+                () -> assertThat(images.get(0).getName()).isEqualTo("뽀또A"),
+                () -> assertThat(images.get(0).getVoteCount()).isEqualTo(0),
+                () -> assertThat(images.get(1).getImageFileId()).isEqualTo(2L),
+                () -> assertThat(images.get(1).getName()).isEqualTo("뽀또B"),
+                () -> assertThat(images.get(1).getVoteCount()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    @DisplayName("게시글 작성 - 이미지가 2개 미만인 경우")
+    void create_invalidPostImageCount() throws Exception {
+        //given
+        long userId = 1L;
+        CreatePostRequest request = new CreatePostRequest("description", List.of(
+                new VoteRequestDto(1L)
+        ));
+
+        //when then
+        assertThatThrownBy(() -> postService.create(userId, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.INVALID_POST_IMAGE_COUNT.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 작성 - 설명이 100자 넘어가는 경우")
+    void create_descriptionCountExceeded() throws Exception {
+        //given
+        long userId = 1L;
+        CreatePostRequest request = new CreatePostRequest("a".repeat(101), List.of(
+                new VoteRequestDto(1L),
+                new VoteRequestDto(2L)
+        ));
+
+        //when then
+        assertThatThrownBy(() -> postService.create(userId, request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED.getMessage());
+    }
+}

--- a/src/test/java/com/swyp8team2/post/domain/PostImageTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostImageTest.java
@@ -1,0 +1,44 @@
+package com.swyp8team2.post.domain;
+
+import com.swyp8team2.common.exception.InternalServerException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostImageTest {
+
+    @Test
+    @DisplayName("게시글 이미지 생성")
+    void create() throws Exception {
+        //given
+        String name = "뽀또A";
+        long imageFileId = 1L;
+
+        //when
+        PostImage postImage = PostImage.create(name, imageFileId);
+
+        //then
+        assertAll(
+                () -> assertThat(postImage.getName()).isEqualTo(name),
+                () -> assertThat(postImage.getImageFileId()).isEqualTo(imageFileId),
+                () -> assertThat(postImage.getVoteCount()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    @DisplayName("게시글 이미지 생성 - null 값이 들어온 경우")
+    void create_null() throws Exception {
+        //given
+
+        //when then
+        assertAll(
+                () -> assertThatThrownBy(() -> PostImage.create(null, 1L))
+                        .isInstanceOf(InternalServerException.class),
+                () -> assertThatThrownBy(() -> PostImage.create("뽀또A", null))
+                        .isInstanceOf(InternalServerException.class)
+        );
+    }
+}

--- a/src/test/java/com/swyp8team2/post/domain/PostTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostTest.java
@@ -1,0 +1,100 @@
+package com.swyp8team2.post.domain;
+
+import com.swyp8team2.common.exception.BadRequestException;
+import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.common.exception.InternalServerException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostTest {
+
+    @Test
+    @DisplayName("게시글 생성")
+    void create() throws Exception {
+        //given
+        long userId = 1L;
+        String description = "description";
+        List<PostImage> postImages = List.of(
+                PostImage.create("뽀또A", 1L),
+                PostImage.create("뽀또B", 2L)
+        );
+        String shareUrl = "shareUrl";
+
+        //when
+        Post post = Post.create(userId, description, postImages, shareUrl);
+
+        //then
+        List<PostImage> images = post.getImages();
+        assertAll(
+                () -> assertThat(post.getUserId()).isEqualTo(userId),
+                () -> assertThat(post.getDescription()).isEqualTo(description),
+                () -> assertThat(post.getShareUrl()).isEqualTo(shareUrl),
+                () -> assertThat(post.getState()).isEqualTo(State.PROGRESS),
+                () -> assertThat(images).hasSize(2),
+                () -> assertThat(images.get(0).getName()).isEqualTo("뽀또A"),
+                () -> assertThat(images.get(0).getImageFileId()).isEqualTo(1L),
+                () -> assertThat(images.get(0).getVoteCount()).isEqualTo(0),
+                () -> assertThat(images.get(1).getName()).isEqualTo("뽀또B"),
+                () -> assertThat(images.get(1).getImageFileId()).isEqualTo(2L),
+                () -> assertThat(images.get(1).getVoteCount()).isEqualTo(0)
+        );
+    }
+
+    @Test
+    @DisplayName("게시글 생성 - 이미지가 2개 미만인 경우")
+    void create_invalidPostImageCount() throws Exception {
+        //given
+        List<PostImage> postImages = List.of(
+                PostImage.create("뽀또A", 1L)
+        );
+
+        //when then
+        assertThatThrownBy(() -> Post.create(1L, "description", postImages, "shareUrl"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.INVALID_POST_IMAGE_COUNT.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 생성 - 설명이 100자 넘어가는 경우")
+    void create_descriptionCountExceeded() throws Exception {
+        //given
+        String description = "a".repeat(101);
+        List<PostImage> postImages = List.of(
+                PostImage.create("뽀또A", 1L),
+                PostImage.create("뽀또B", 2L)
+        );
+
+        //when then
+        assertThatThrownBy(() -> Post.create(1L, description, postImages, "shareUrl"))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 생성 - null 값이 들어오는 경우")
+    void create_null() throws Exception {
+        //given
+
+        //when then
+        assertAll(
+                () -> assertThatThrownBy(() -> Post.create(null, "description", List.of(), "shareUrl"))
+                        .isInstanceOf(InternalServerException.class)
+                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
+                () -> assertThatThrownBy(() -> Post.create(1L, null, List.of(), "shareUrl"))
+                        .isInstanceOf(InternalServerException.class)
+                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
+                () -> assertThatThrownBy(() -> Post.create(1L, "description", List.of(), null))
+                        .isInstanceOf(InternalServerException.class)
+                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
+                () -> assertThatThrownBy(() -> Post.create(1L, "description", null, "shareUrl"))
+                        .isInstanceOf(InternalServerException.class)
+                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage())
+        );
+    }
+}

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -56,7 +56,7 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("description")
                                         .type(JsonFieldType.STRING)
                                         .description("설명")
-                                        .attributes(constraints("1~200자 사이")),
+                                        .attributes(constraints("0~100자 사이")),
                                 fieldWithPath("votes")
                                         .type(JsonFieldType.ARRAY)
                                         .description("투표 후보")

--- a/src/test/java/com/swyp8team2/support/WebUnitTest.java
+++ b/src/test/java/com/swyp8team2/support/WebUnitTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp8team2.auth.application.AuthService;
 import com.swyp8team2.auth.presentation.RefreshTokenCookieGenerator;
 import com.swyp8team2.image.application.ImageService;
+import com.swyp8team2.post.application.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -28,4 +29,7 @@ public abstract class WebUnitTest {
 
     @MockitoBean
     protected ImageService imageService;
+
+    @MockitoBean
+    protected PostService postService;
 }


### PR DESCRIPTION
## 🚀 작업 내용 설명

- 게시글 생성 기능 추가
- docs 구현 현황 추가

## 📢 그 외

각자 개발하는 부분에서 게시글이 있어야 할 것 같아서 생성 기능만 추가해서 올렸습니다.
shareUrl 부분은 post/:id, post/난수 어떤 방식으로 할지 결정이 나지 않았던 것 같아서 우선 미구현 상태로 냅뒀습니다.

docs에도 구현 여부에 따라 `(미구현)` 붙여놔서 나중에 구현 다 하시면 지워주시면 될 것 같아요!

## 📌 관련 이슈
