### PR TITLE
소셜 로그인 인가 코드 발급 방식 변경

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,11 +1,6 @@
 [[인증-API]]
 == 인증 API
 
-[[카카오-로그인-리다이렉트]]
-=== 카카오 로그인 리다이렉트
-
-operation::auth-controller-test/kakao-o-auth[snippets='http-request,curl-request,http-response']
-
 [[카카오-로그인]]
 === 카카오 로그인
 

--- a/src/main/java/com/swyp8team2/auth/application/AuthService.java
+++ b/src/main/java/com/swyp8team2/auth/application/AuthService.java
@@ -21,13 +21,9 @@ public class AuthService {
     private final SocialAccountRepository socialAccountRepository;
     private final UserService userService;
 
-    public String getOAuthAuthorizationUrl() {
-        return oAuthService.getOAuthAuthorizationUrl();
-    }
-
     @Transactional
-    public TokenPair oauthSignIn(String code) {
-        OAuthUserInfo oAuthUserInfo = oAuthService.getUserInfo(code);
+    public TokenPair oauthSignIn(String code, String redirectUri) {
+        OAuthUserInfo oAuthUserInfo = oAuthService.getUserInfo(code, redirectUri);
         SocialAccount socialAccount = socialAccountRepository.findBySocialIdAndProvider(
                         oAuthUserInfo.socialId(),
                         Provider.KAKAO

--- a/src/main/java/com/swyp8team2/auth/application/jwt/JwtProvider.java
+++ b/src/main/java/com/swyp8team2/auth/application/jwt/JwtProvider.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class JwtProvider {
 
     private static final long ACCESS_TOKEN_EXPIRATION_MINUTES = 30;
-    private static final long REFRESH_TOKEN_EXPIRATION_HOUR_MINUTES = 60 * 24 * 14;
+    private static final long REFRESH_TOKEN_EXPIRATION_MINUTES = 60 * 24 * 14;
 
     private final Key key;
     private final Clock clock;
@@ -51,7 +51,7 @@ public class JwtProvider {
     }
 
     public String createRefreshToken(JwtClaim claim) {
-        return createToken(claim, REFRESH_TOKEN_EXPIRATION_HOUR_MINUTES);
+        return createToken(claim, REFRESH_TOKEN_EXPIRATION_MINUTES);
     }
 
     private String createToken(JwtClaim claim, long expiration) {

--- a/src/main/java/com/swyp8team2/auth/application/oauth/OAuthService.java
+++ b/src/main/java/com/swyp8team2/auth/application/oauth/OAuthService.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Service
@@ -22,19 +21,9 @@ public class OAuthService {
     private final KakaoOAuthConfig kakaoOAuthConfig;
     private final KakaoOAuthClient kakaoOAuthClient;
 
-    public String getOAuthAuthorizationUrl() {
-        return UriComponentsBuilder
-                .fromUriString(kakaoOAuthConfig.authorizationUri())
-                .queryParam("client_id", kakaoOAuthConfig.clientId())
-                .queryParam("redirect_uri", kakaoOAuthConfig.redirectUri())
-                .queryParam("response_type", "code")
-                .queryParam("scope", String.join(",", kakaoOAuthConfig.scope()))
-                .toUriString();
-    }
-
-    public OAuthUserInfo getUserInfo(String code) {
+    public OAuthUserInfo getUserInfo(String code, String redirectUri) {
         try {
-            KakaoAuthResponse kakaoAuthResponse = kakaoOAuthClient.fetchToken(tokenRequestParams(code));
+            KakaoAuthResponse kakaoAuthResponse = kakaoOAuthClient.fetchToken(tokenRequestParams(code, redirectUri));
             return kakaoOAuthClient
                     .fetchUserInfo(BEARER + kakaoAuthResponse.accessToken())
                     .toOAuthUserInfo();
@@ -44,11 +33,11 @@ public class OAuthService {
         }
     }
 
-    private MultiValueMap<String, String> tokenRequestParams(String authCode) {
+    private MultiValueMap<String, String> tokenRequestParams(String authCode, String redirectUri) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", kakaoOAuthConfig.clientId());
-        params.add("redirect_uri", kakaoOAuthConfig.redirectUri());
+        params.add("redirect_uri", redirectUri);
         params.add("code", authCode);
         params.add("client_secret", kakaoOAuthConfig.clientSecret());
         return params;

--- a/src/main/java/com/swyp8team2/auth/presentation/AuthController.java
+++ b/src/main/java/com/swyp8team2/auth/presentation/AuthController.java
@@ -2,7 +2,6 @@ package com.swyp8team2.auth.presentation;
 
 
 import com.swyp8team2.auth.application.AuthService;
-import com.swyp8team2.auth.application.jwt.JwtService;
 import com.swyp8team2.auth.application.jwt.TokenPair;
 import com.swyp8team2.auth.presentation.dto.OAuthSignInRequest;
 import com.swyp8team2.auth.presentation.dto.TokenResponse;
@@ -13,15 +12,11 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Objects;
@@ -34,20 +29,12 @@ public class AuthController {
     private final RefreshTokenCookieGenerator refreshTokenCookieGenerator;
     private final AuthService authService;
 
-    @GetMapping("/oauth2/kakao")
-    public ResponseEntity<Void> kakaoOAuth() {
-        String requestUrl = authService.getOAuthAuthorizationUrl();
-        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
-                .header(HttpHeaders.LOCATION, requestUrl)
-                .build();
-    }
-
     @PostMapping("/oauth2/code/kakao")
     public ResponseEntity<TokenResponse> kakaoOAuthSignIn(
             @Valid @RequestBody OAuthSignInRequest request,
             HttpServletResponse response
     ) {
-        TokenPair tokenPair = authService.oauthSignIn(request.code());
+        TokenPair tokenPair = authService.oauthSignIn(request.code(), request.redirectUri());
         Cookie cookie = refreshTokenCookieGenerator.createCookie(tokenPair.refreshToken());
         response.addCookie(cookie);
         return ResponseEntity.ok(new TokenResponse(tokenPair.accessToken()));

--- a/src/main/java/com/swyp8team2/auth/presentation/dto/OAuthSignInRequest.java
+++ b/src/main/java/com/swyp8team2/auth/presentation/dto/OAuthSignInRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotNull;
 
 public record OAuthSignInRequest(
         @NotNull
-        String code
+        String code,
+
+        @NotNull
+        String redirectUri
 ) {
 }

--- a/src/main/java/com/swyp8team2/common/config/KakaoOAuthConfig.java
+++ b/src/main/java/com/swyp8team2/common/config/KakaoOAuthConfig.java
@@ -7,7 +7,6 @@ public record KakaoOAuthConfig(
         String authorizationUri,
         String clientId,
         String clientSecret,
-        String redirectUri,
         String[] scope,
         String userInfoUri
 ) {

--- a/src/test/java/com/swyp8team2/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/swyp8team2/auth/application/AuthServiceTest.java
@@ -45,14 +45,14 @@ class AuthServiceTest extends IntegrationTest {
     void oAuthSignIn() throws Exception {
         //given
         OAuthUserInfo oAuthUserInfo = new OAuthUserInfo("socialId", "profileImageUrl", "nickname", Provider.KAKAO);
-        given(oAuthService.getUserInfo(anyString()))
+        given(oAuthService.getUserInfo(anyString(), anyString()))
                 .willReturn(oAuthUserInfo);
         TokenPair expectedTokenPair = new TokenPair("accessToken", "refreshToken");
         given(jwtProvider.createToken(any()))
                 .willReturn(expectedTokenPair);
 
         //when
-        TokenPair tokenPair = authService.oauthSignIn("code");
+        TokenPair tokenPair = authService.oauthSignIn("code", "https://dev.photopic.site");
 
         //then
         SocialAccount socialAccount = socialAccountRepository.findBySocialIdAndProvider(oAuthUserInfo.socialId(), Provider.KAKAO).get();


### PR DESCRIPTION
## 🚀 작업 내용 설명

- 소셜 로그인 인가 코드 발급 방식을 프런트에서 전부 처리하기로 변경

## 📢 그 외

프런트 로컬, 개발 환경에 상관 없이 개발하려면 인가 코드를 발급받을 때 redirect_uri가 변동이 가능해야해서, 인가 코드 발급 받고 인가 코드를 백엔드에 보낼 때 redirect_uri를 같이 보내줘서 환경 상관 없이 개발할 수 있도록 수정했습니다.

## 📌 관련 이슈
