### PR TITLE
Feature/comment

### DIFF
--- a/src/docs/asciidoc/comments.adoc
+++ b/src/docs/asciidoc/comments.adoc
@@ -2,12 +2,12 @@
 == 댓글 API
 
 [[댓글-생성]]
-=== 댓글 생성 (미구현)
+=== 댓글 생성
 
 operation::comment-controller-test/create-comment[snippets='http-request,curl-request,path-parameters,request-headers,request-fields,http-response']
 
 [[댓글-조회]]
-=== 댓글 조회 (미구현)
+=== 댓글 조회
 
 operation::comment-controller-test/find-comments[snippets='http-request,curl-request,path-parameters,http-response,response-fields']
 

--- a/src/main/java/com/swyp8team2/comment/application/CommentService.java
+++ b/src/main/java/com/swyp8team2/comment/application/CommentService.java
@@ -1,0 +1,2 @@
+package com.swyp8team2.comment.application;public class CommentService {
+}

--- a/src/main/java/com/swyp8team2/comment/application/CommentService.java
+++ b/src/main/java/com/swyp8team2/comment/application/CommentService.java
@@ -1,2 +1,44 @@
-package com.swyp8team2.comment.application;public class CommentService {
+package com.swyp8team2.comment.application;
+
+import com.swyp8team2.auth.domain.UserInfo;
+import com.swyp8team2.comment.domain.Comment;
+import com.swyp8team2.comment.domain.CommentRepository;
+import com.swyp8team2.comment.presentation.dto.CommentResponse;
+import com.swyp8team2.comment.presentation.dto.CreateCommentRequest;
+import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
+import com.swyp8team2.user.domain.User;
+import com.swyp8team2.user.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class CommentService {
+
+    private final UserRepository userRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public void createComment(Long postId, CreateCommentRequest request, UserInfo userInfo) {
+        Comment comment = new Comment(postId, userInfo.userId(), request.content());
+        commentRepository.save(comment);
+    }
+
+    public CursorBasePaginatedResponse<CommentResponse> selectComments(Long postId, Long cursor, int size) {
+        Slice<Comment> commentSlice = commentRepository.findByPostId(postId, cursor, PageRequest.of(0, size));
+        return CursorBasePaginatedResponse.of(commentSlice.map(this::createCommentResponse));
+    }
+
+    private CommentResponse createCommentResponse(Comment comment) {
+        Optional<User> user = userRepository.findById(comment.getUserNo());
+        return CommentResponse.of(comment, user.get());
+    }
 }

--- a/src/main/java/com/swyp8team2/comment/domain/Comment.java
+++ b/src/main/java/com/swyp8team2/comment/domain/Comment.java
@@ -1,0 +1,2 @@
+package com.swyp8team2.comment.domain;public class Comment {
+}

--- a/src/main/java/com/swyp8team2/comment/domain/Comment.java
+++ b/src/main/java/com/swyp8team2/comment/domain/Comment.java
@@ -1,7 +1,11 @@
 package com.swyp8team2.comment.domain;
 
 import com.swyp8team2.common.domain.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.GenerationType;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/com/swyp8team2/comment/domain/Comment.java
+++ b/src/main/java/com/swyp8team2/comment/domain/Comment.java
@@ -1,2 +1,48 @@
-package com.swyp8team2.comment.domain;public class Comment {
+package com.swyp8team2.comment.domain;
+
+import com.swyp8team2.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static com.swyp8team2.common.util.Validator.validateEmptyString;
+import static com.swyp8team2.common.util.Validator.validateNull;
+
+@Entity
+@Getter
+@Table(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    private Long postId;
+
+    @NotNull
+    private Long userNo;
+
+    @NotNull
+    private String content;
+
+    public Comment(Long id, Long postId, Long userNo, String content) {
+        validateNull(postId, userNo);
+        validateEmptyString(content);
+        this.id = id;
+        this.postId = postId;
+        this.userNo = userNo;
+        this.content = content;
+    }
+
+    public Comment(Long postId, Long userNo, String content) {
+        validateNull(postId, userNo);
+        validateEmptyString(content);
+        this.postId = postId;
+        this.userNo = userNo;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
+++ b/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
@@ -1,0 +1,2 @@
+package com.swyp8team2.comment.domain;public interface CommentRepository {
+}

--- a/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
+++ b/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
@@ -1,2 +1,24 @@
-package com.swyp8team2.comment.domain;public interface CommentRepository {
+package com.swyp8team2.comment.domain;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("""
+            SELECT c
+            FROM Comment c
+            WHERE c.postId = :postId
+                AND (:cursor is null or c.id > :cursor)
+            ORDER BY c.createdAt DESC 
+            """)
+    Slice<Comment> findByPostId(
+            Long postId,
+            Long cursor,
+            Pageable pageable);
+
 }

--- a/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
+++ b/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
@@ -1,6 +1,7 @@
 package com.swyp8team2.comment.presentation;
 
 import com.swyp8team2.auth.domain.UserInfo;
+import com.swyp8team2.comment.application.CommentService;
 import com.swyp8team2.comment.presentation.dto.AuthorDto;
 import com.swyp8team2.comment.presentation.dto.CommentResponse;
 import com.swyp8team2.comment.presentation.dto.CreateCommentRequest;
@@ -26,35 +27,26 @@ import java.util.List;
 @RequestMapping("/posts/{postId}/comments")
 public class CommentController {
 
+    private final CommentService commentService;
+
     @PostMapping("")
     public ResponseEntity<Void> createComment(
             @PathVariable("postId") Long postId,
             @Valid @RequestBody CreateCommentRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
+        commentService.createComment(postId, request, userInfo);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("")
-    public ResponseEntity<CursorBasePaginatedResponse<CommentResponse>> findComments(
+    public ResponseEntity<CursorBasePaginatedResponse<CommentResponse>> selectComments(
             @PathVariable("postId") Long postId,
             @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        CursorBasePaginatedResponse<CommentResponse> response = new CursorBasePaginatedResponse<>(
-                1L,
-                false,
-                List.of(
-                        new CommentResponse(
-                                1L,
-                                "content",
-                                new AuthorDto(1L, "author", "https://image.com/profile-image"),
-                                1L,
-                                LocalDateTime.of(2025, 2, 13, 12, 0)
-                        )
-                )
-        );
+        CursorBasePaginatedResponse<CommentResponse> response = commentService.selectComments(postId, cursor, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
+++ b/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
@@ -46,7 +46,7 @@ public class CommentController {
             @RequestParam(value = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        CursorBasePaginatedResponse<CommentResponse> response = commentService.selectComments(postId, cursor, size);
+        CursorBasePaginatedResponse<CommentResponse> response = commentService.findComments(postId, cursor, size);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/swyp8team2/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/swyp8team2/comment/presentation/dto/CommentResponse.java
@@ -1,12 +1,30 @@
 package com.swyp8team2.comment.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.swyp8team2.comment.domain.Comment;
+import com.swyp8team2.common.dto.CursorDto;
+import com.swyp8team2.user.domain.User;
+
 import java.time.LocalDateTime;
 
 public record CommentResponse(
         Long commentId,
         String content,
         AuthorDto author,
-        Long voteId,
         LocalDateTime createdAt
-) {
+) implements CursorDto {
+
+    @Override
+    @JsonIgnore
+    public long getId() {
+        return commentId;
+    }
+
+    public static CommentResponse of(Comment comment, User user) {
+        return new CommentResponse(comment.getId(),
+                                    comment.getContent(),
+                                    new AuthorDto(user.getId(), user.getNickname(), user.getProfileUrl()),
+                                    comment.getCreatedAt()
+                );
+    }
 }

--- a/src/main/java/com/swyp8team2/comment/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/swyp8team2/comment/presentation/dto/CommentResponse.java
@@ -11,6 +11,7 @@ public record CommentResponse(
         Long commentId,
         String content,
         AuthorDto author,
+        Long voteId,
         LocalDateTime createdAt
 ) implements CursorDto {
 
@@ -24,6 +25,7 @@ public record CommentResponse(
         return new CommentResponse(comment.getId(),
                                     comment.getContent(),
                                     new AuthorDto(user.getId(), user.getNickname(), user.getProfileUrl()),
+                                    null,
                                     comment.getCreatedAt()
                 );
     }

--- a/src/main/java/com/swyp8team2/common/config/JpaConfig.java
+++ b/src/main/java/com/swyp8team2/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.swyp8team2.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/swyp8team2/common/domain/AuditorAwareImpl.java
+++ b/src/main/java/com/swyp8team2/common/domain/AuditorAwareImpl.java
@@ -1,0 +1,2 @@
+package com.swyp8team2.common.domain;public class AuditorAwareImpl {
+}

--- a/src/main/java/com/swyp8team2/common/domain/BaseEntity.java
+++ b/src/main/java/com/swyp8team2/common/domain/BaseEntity.java
@@ -2,7 +2,10 @@ package com.swyp8team2.common.domain;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -10,14 +13,17 @@ import java.time.LocalDateTime;
 
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@Getter
 public abstract class BaseEntity {
 
-    private String createdBy;
+    @CreatedBy
+    private Long createdBy;
 
     @CreatedDate
     private LocalDateTime createdAt;
 
-    private String updatedBy;
+    @LastModifiedBy
+    private Long updatedBy;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;

--- a/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
@@ -1,2 +1,92 @@
-package com.swyp8team2.comment.application;public class CommentServiceTest {
+package com.swyp8team2.comment.application;
+
+import com.swyp8team2.auth.domain.UserInfo;
+import com.swyp8team2.comment.domain.Comment;
+import com.swyp8team2.comment.domain.CommentRepository;
+import com.swyp8team2.comment.presentation.dto.CommentResponse;
+import com.swyp8team2.comment.presentation.dto.CreateCommentRequest;
+import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
+import com.swyp8team2.user.domain.User;
+import com.swyp8team2.user.domain.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글 생성")
+    void createComment() {
+        // given
+        Long postId = 1L;
+        CreateCommentRequest request = new CreateCommentRequest("테스트 댓글");
+        UserInfo userInfo = new UserInfo(100L);
+        Comment comment = new Comment(postId, userInfo.userId(), request.content());
+
+        // when
+        when(commentRepository.save(any(Comment.class))).thenReturn(comment);
+
+        // then
+        assertDoesNotThrow(() -> commentService.createComment(postId, request, userInfo));
+    }
+
+    @Test
+    @DisplayName("댓글 조회")
+    void selectComments() {
+        // given
+        Long postId = 1L;
+        Long cursor = null;
+        int size = 2;
+
+        Comment comment1 = new Comment(1L, postId, 100L, "첫 번째 댓글");
+        Comment comment2 = new Comment(2L, postId, 100L, "두 번째 댓글");
+        SliceImpl<Comment> commentSlice = new SliceImpl<>(List.of(comment1, comment2), PageRequest.of(0, size), false);
+        User user = new User(100L, "닉네임","http://example.com/profile.png");
+
+        // Mock 설정
+        given(commentRepository.findByPostId(eq(postId), eq(cursor), any(PageRequest.class))).willReturn(commentSlice);
+        // 각 댓글마다 user_no=100L 이므로, findById(100L)만 호출됨
+        given(userRepository.findById(100L)).willReturn(Optional.of(user));
+
+        // when
+        CursorBasePaginatedResponse<CommentResponse> response = commentService.selectComments(postId, cursor, size);
+
+        // then
+        assertThat(response.data()).hasSize(2);
+
+        CommentResponse cr1 = response.data().get(0);
+        assertThat(cr1.commentId()).isEqualTo(1L);
+        assertThat(cr1.content()).isEqualTo("첫 번째 댓글");
+        assertThat(cr1.author().nickname()).isEqualTo("닉네임");
+
+        CommentResponse cr2 = response.data().get(1);
+        assertThat(cr2.commentId()).isEqualTo(2L);
+        assertThat(cr2.content()).isEqualTo("두 번째 댓글");
+    }
+
 }

--- a/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
@@ -1,0 +1,2 @@
+package com.swyp8team2.comment.application;public class CommentServiceTest {
+}

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class CommentRepositoryTest {
+  
+}

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -31,13 +31,11 @@ class CommentRepositoryTest {
 
         // then
         assertThat(result1.getContent()).hasSize(3);
-        assertThat(result1.getContent().getFirst().getUserNo()).isEqualTo(100L);
 
         // when2
         Slice<Comment> result2 = commentRepository.findByPostId(1L, 1L, PageRequest.of(0, 10));
 
         // then2
         assertThat(result2.getContent()).hasSize(2);
-        assertThat(result2.getContent().getFirst().getUserNo()).isEqualTo(101L);
     }
 }

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -23,15 +23,15 @@ class CommentRepositoryTest {
         // given
         Comment comment1 = new Comment(1L, 100L, "content1");
         Comment comment2 = new Comment(1L, 101L, "content2");
-        Comment comment3 = new Comment(2L, 102L, "content3");
-        Comment comment4 = new Comment(1L, 103L, "content4");
-        commentRepository.saveAll(List.of(comment1, comment2, comment3, comment4));
+        Comment comment3 = new Comment(1L, 102L, "content3");
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
 
         // when
         Slice<Comment> result1 = commentRepository.findByPostId(1L, null, PageRequest.of(0, 10));
 
         // then
         assertThat(result1.getContent()).hasSize(3);
+        assertThat(result1.getContent().getFirst().getUserNo()).isEqualTo(100L);
 
         // when2
         Slice<Comment> result2 = commentRepository.findByPostId(1L, 1L, PageRequest.of(0, 10));

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -1,4 +1,43 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.swyp8team2.comment.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
 class CommentRepositoryTest {
-  
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Test
+    @DisplayName("댓글 조회")
+    void select_CommentUser() {
+        // given
+        Comment comment1 = new Comment(1L, 100L, "content1");
+        Comment comment2 = new Comment(1L, 101L, "content2");
+        Comment comment3 = new Comment(2L, 102L, "content3");
+        Comment comment4 = new Comment(1L, 103L, "content4");
+        commentRepository.saveAll(List.of(comment1, comment2, comment3, comment4));
+
+        // when
+        Slice<Comment> result1 = commentRepository.findByPostId(1L, null, PageRequest.of(0, 10));
+
+        // then
+        assertThat(result1.getContent()).hasSize(3);
+
+        // when2
+        Slice<Comment> result2 = commentRepository.findByPostId(1L, 1L, PageRequest.of(0, 10));
+
+        // then2
+        assertThat(result2.getContent()).hasSize(2);
+        assertThat(result2.getContent().getFirst().getUserNo()).isEqualTo(101L);
+    }
 }

--- a/src/test/java/com/swyp8team2/comment/presentation/CommentControllerTest.java
+++ b/src/test/java/com/swyp8team2/comment/presentation/CommentControllerTest.java
@@ -1,5 +1,6 @@
 package com.swyp8team2.comment.presentation;
 
+import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.comment.presentation.dto.AuthorDto;
 import com.swyp8team2.comment.presentation.dto.CommentResponse;
 import com.swyp8team2.comment.presentation.dto.CreateCommentRequest;
@@ -14,8 +15,12 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithAnonymousUser;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -25,13 +30,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class CommentControllerTest extends RestDocsTest {
 
-
     @Test
     @WithMockUserInfo
     @DisplayName("댓글 생성")
     void createComment() throws Exception {
         //given
+        Long postId = 1L;
         CreateCommentRequest request = new CreateCommentRequest("content");
+
+        doNothing().when(commentService).createComment(eq(postId), any(CreateCommentRequest.class), any(UserInfo.class));
 
         //when then
         mockMvc.perform(post("/posts/{postId}/comments", "1")
@@ -48,26 +55,30 @@ class CommentControllerTest extends RestDocsTest {
                                 fieldWithPath("content").type(JsonFieldType.STRING).description("댓글 내용").attributes(constraints("최대 ?글자"))
                         )
                 ));
+
+        verify(commentService, times(1)).createComment(eq(postId), any(CreateCommentRequest.class), any(UserInfo.class));
     }
 
     @Test
     @WithAnonymousUser
     @DisplayName("댓글 조회")
-    void findComments() throws Exception {
+    void selectComments() throws Exception {
         //given
-        CursorBasePaginatedResponse<CommentResponse> response = new CursorBasePaginatedResponse<>(
+        Long postId = 1L;
+        Long cursor = null;
+        int size = 10;
+        CommentResponse commentResponse = new CommentResponse(
                 1L,
-                false,
-                List.of(
-                        new CommentResponse(
-                                1L,
-                                "content",
-                                new AuthorDto(1L, "author", "https://image.com/profile-image"),
-                                1L,
-                                LocalDateTime.of(2025, 2, 13, 12, 0)
-                        )
-                )
+                "댓글 내용",
+                new AuthorDto(100L, "닉네임", "http://example.com/profile.png"),
+                LocalDateTime.now()
         );
+        List<CommentResponse> commentList = Collections.singletonList(commentResponse);
+
+        CursorBasePaginatedResponse<CommentResponse> response =
+                new CursorBasePaginatedResponse<>(null, false, commentList);
+
+        when(commentService.selectComments(eq(postId), eq(cursor), eq(size))).thenReturn(response);
 
         //when
         mockMvc.perform(get("/posts/{postId}/comments", "1"))
@@ -107,15 +118,13 @@ class CommentControllerTest extends RestDocsTest {
                                 fieldWithPath("data[].author.profileUrl")
                                         .type(JsonFieldType.STRING)
                                         .description("작성자 프로필 이미지 url"),
-                                fieldWithPath("data[].voteId")
-                                        .type(JsonFieldType.NUMBER)
-                                        .optional()
-                                        .description("작성자 투표 Id (투표 없을 시 null)"),
                                 fieldWithPath("data[].createdAt")
                                         .type(JsonFieldType.STRING)
                                         .description("댓글 작성일")
                                 )
                 ));
+
+        verify(commentService, times(1)).selectComments(eq(postId), eq(cursor), eq(size));
     }
 
     @Test

--- a/src/test/java/com/swyp8team2/comment/presentation/CommentControllerTest.java
+++ b/src/test/java/com/swyp8team2/comment/presentation/CommentControllerTest.java
@@ -71,6 +71,7 @@ class CommentControllerTest extends RestDocsTest {
                 1L,
                 "댓글 내용",
                 new AuthorDto(100L, "닉네임", "http://example.com/profile.png"),
+                null,
                 LocalDateTime.now()
         );
         List<CommentResponse> commentList = Collections.singletonList(commentResponse);
@@ -78,7 +79,7 @@ class CommentControllerTest extends RestDocsTest {
         CursorBasePaginatedResponse<CommentResponse> response =
                 new CursorBasePaginatedResponse<>(null, false, commentList);
 
-        when(commentService.selectComments(eq(postId), eq(cursor), eq(size))).thenReturn(response);
+        when(commentService.findComments(eq(postId), eq(cursor), eq(size))).thenReturn(response);
 
         //when
         mockMvc.perform(get("/posts/{postId}/comments", "1"))
@@ -118,13 +119,17 @@ class CommentControllerTest extends RestDocsTest {
                                 fieldWithPath("data[].author.profileUrl")
                                         .type(JsonFieldType.STRING)
                                         .description("작성자 프로필 이미지 url"),
+                                fieldWithPath("data[].voteId")
+                                        .type(JsonFieldType.NUMBER)
+                                        .optional()
+                                        .description("작성자 투표 Id (투표 없을 시 null)"),
                                 fieldWithPath("data[].createdAt")
                                         .type(JsonFieldType.STRING)
                                         .description("댓글 작성일")
                                 )
                 ));
 
-        verify(commentService, times(1)).selectComments(eq(postId), eq(cursor), eq(size));
+        verify(commentService, times(1)).findComments(eq(postId), eq(cursor), eq(size));
     }
 
     @Test

--- a/src/test/java/com/swyp8team2/support/WebUnitTest.java
+++ b/src/test/java/com/swyp8team2/support/WebUnitTest.java
@@ -3,6 +3,7 @@ package com.swyp8team2.support;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.swyp8team2.auth.application.AuthService;
 import com.swyp8team2.auth.presentation.RefreshTokenCookieGenerator;
+import com.swyp8team2.comment.application.CommentService;
 import com.swyp8team2.image.application.ImageService;
 import com.swyp8team2.post.application.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,4 +33,7 @@ public abstract class WebUnitTest {
 
     @MockitoBean
     protected PostService postService;
+
+    @MockitoBean
+    protected CommentService commentService;
 }


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 댓글 생성 추가
- 댓글 조회 추가

## 📢 그 외
- 지금은 BaseEntity에서 createdBy, updatedBy가 null로 들어갑니다. 별도로 Auditor 설정을 해야하는데 현재 UserInfo의 userId 값으로 넣으려고 하지만 이 값이 Long 타입이어서 1차 MVP 이후에 다시 검토할 예정입니다.

## 📌 관련 이슈
#24 