### PR TITLE
투표, 게시글 관련 기능 추가

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -7,13 +7,11 @@
 operation::auth-controller-test/kakao-o-auth[snippets='http-request,curl-request,http-response']
 
 [[카카오-로그인]]
-=== 카카오 로그인
+=== `POST` 카카오 로그인
 
 operation::auth-controller-test/kakao-o-auth-sign-in[snippets='http-request,curl-request,request-fields,http-response,response-cookies,response-fields']
 
-[[네이버-로그인]]
-
 [[토큰-재발급]]
-=== 토큰 재발급
+=== `POST` 토큰 재발급
 
 operation::auth-controller-test/reissue[snippets='http-request,curl-request,request-cookies,http-response,response-cookies,response-fields']

--- a/src/docs/asciidoc/images.adoc
+++ b/src/docs/asciidoc/images.adoc
@@ -2,6 +2,6 @@
 == 이미지 API
 
 [[이미지-업로드]]
-=== 이미지 업로드
+=== `POST` 이미지 업로드
 
 operation::image-controller-test/create-image-file[snippets='http-request,curl-request,request-headers,request-parts,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -63,6 +63,16 @@ Content-Type: application/json;charset=UTF-8
 Authorization: Bearer accessToken
 ```
 
+#### 테스트용 개발 토큰
+
+```
+user1
+eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEiLCJpYXQiOjE3NDAyOTQyMzEsImlzcyI6InN3eXA4dGVhbTIiLCJleHAiOjMzMjc2Mjk0MjMxfQ.gqA245tRiBQB9owKRWIpX1we1T362R-xDTt4YT9AhRY
+
+user2
+eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIiLCJpYXQiOjE3NDA0NDM0ODIsImlzcyI6InN3eXA4dGVhbTIiLCJleHAiOjMzMjc2NDQzNDgyfQ.2sTlCtSHb4eGzhlL6WlRT6xvJLtvipnHp6EAmC4j1UQ
+```
+
 [[인증-예외]]
 === 인증 예외
 

--- a/src/docs/asciidoc/posts.adoc
+++ b/src/docs/asciidoc/posts.adoc
@@ -2,7 +2,7 @@
 == 게시글 API
 
 [[게시글-작성]]
-=== 게시글 작성
+=== `POST` 게시글 작성
 
 operation::post-controller-test/create-post[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
@@ -12,12 +12,12 @@ operation::post-controller-test/create-post[snippets='http-request,curl-request,
 operation::post-controller-test/find-post[snippets='http-request,curl-request,path-parameters,http-response,response-fields']
 
 [[내가-작성한-게시글-조회]]
-=== 내가 작성한 게시글 조회 (미구현)
+=== `GET` 내가 작성한 게시글 조회
 
 operation::post-controller-test/find-my-post[snippets='http-request,curl-request,query-parameters,request-headers,http-response,response-fields']
 
 [[내가-참여한-게시글-조회]]
-=== 내가 참여한 게시글 조회 (미구현)
+=== `GET` 내가 참여한 게시글 조회
 
 operation::post-controller-test/find-voted-post[snippets='http-request,curl-request,query-parameters,request-headers,http-response,response-fields']
 

--- a/src/docs/asciidoc/votes.adoc
+++ b/src/docs/asciidoc/votes.adoc
@@ -2,21 +2,21 @@
 == 투표 API
 
 [[투표]]
-=== 투표 (미구현)
+=== `POST` 투표
 
 operation::vote-controller-test/vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게스트-투표]]
-=== 게스트 투표 (미구현)
+=== `POST` 게스트 투표 (미구현)
 
 operation::vote-controller-test/guest-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[투표-변경]]
-=== 투표 변경 (미구현)
+=== 투표 변경 (투표 API로 통일)
 
-operation::vote-controller-test/change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
+// operation::vote-controller-test/change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
 
 [[게스트-투표-변경]]
-=== 게스트 투표 변경 (미구현)
+=== 게스트 투표 변경 (미구현, 게스트 투표 API로 통일)
 
-operation::vote-controller-test/guest-change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
+// operation::vote-controller-test/guest-change-vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']

--- a/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
+++ b/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,11 +15,12 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             FROM Comment c
             WHERE c.postId = :postId
                 AND (:cursor is null or c.id > :cursor)
-            ORDER BY c.createdAt DESC 
+            ORDER BY c.createdAt DESC
             """)
     Slice<Comment> findByPostId(
-            Long postId,
-            Long cursor,
-            Pageable pageable);
+            @Param("postId") Long postId,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
 
 }

--- a/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
+++ b/src/main/java/com/swyp8team2/comment/presentation/CommentController.java
@@ -7,6 +7,7 @@ import com.swyp8team2.comment.presentation.dto.CommentResponse;
 import com.swyp8team2.comment.presentation.dto.CreateCommentRequest;
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -42,8 +43,8 @@ public class CommentController {
     @GetMapping("")
     public ResponseEntity<CursorBasePaginatedResponse<CommentResponse>> selectComments(
             @PathVariable("postId") Long postId,
-            @RequestParam(value = "cursor", required = false) Long cursor,
-            @RequestParam(value = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(value = "cursor", required = false) @Min(0) Long cursor,
+            @RequestParam(value = "size", required = false, defaultValue = "10") @Min(1) int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
         CursorBasePaginatedResponse<CommentResponse> response = commentService.findComments(postId, cursor, size);

--- a/src/main/java/com/swyp8team2/common/config/CommonConfig.java
+++ b/src/main/java/com/swyp8team2/common/config/CommonConfig.java
@@ -3,12 +3,10 @@ package com.swyp8team2.common.config;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.time.Clock;
 
 @Configuration
-@EnableJpaAuditing
 @ConfigurationPropertiesScan
 public class CommonConfig {
 

--- a/src/main/java/com/swyp8team2/common/config/CommonConfig.java
+++ b/src/main/java/com/swyp8team2/common/config/CommonConfig.java
@@ -3,10 +3,12 @@ package com.swyp8team2.common.config;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.time.Clock;
 
 @Configuration
+@EnableJpaAuditing
 @ConfigurationPropertiesScan
 public class CommonConfig {
 

--- a/src/main/java/com/swyp8team2/common/dev/DataInitConfig.java
+++ b/src/main/java/com/swyp8team2/common/dev/DataInitConfig.java
@@ -1,0 +1,19 @@
+package com.swyp8team2.common.dev;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile({"dev", "local"})
+@Component
+@RequiredArgsConstructor
+public class DataInitConfig {
+
+    private final DataInitializer dataInitializer;
+
+    @PostConstruct
+    public void init() {
+        dataInitializer.init();
+    }
+}

--- a/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
+++ b/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
@@ -2,12 +2,24 @@ package com.swyp8team2.common.dev;
 
 import com.swyp8team2.auth.application.jwt.JwtService;
 import com.swyp8team2.auth.application.jwt.TokenPair;
+import com.swyp8team2.image.domain.ImageFile;
+import com.swyp8team2.image.domain.ImageFileRepository;
+import com.swyp8team2.image.presentation.dto.ImageFileDto;
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.post.domain.PostImage;
+import com.swyp8team2.post.domain.PostRepository;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
+import com.swyp8team2.vote.application.VoteService;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 @Profile({"dev", "local"})
 @Component
@@ -15,13 +27,34 @@ import org.springframework.stereotype.Component;
 public class DataInitializer {
 
     private final UserRepository userRepository;
+    private final ImageFileRepository imageFileRepository;
+    private final PostRepository postRepository;
     private final JwtService jwtService;
+    private final VoteService voteService;
 
-    @PostConstruct
+    @Transactional
     public void init() {
-        User save = userRepository.save(User.create("nickname", "defailt_profile_image"));
-        TokenPair tokenPair = jwtService.createToken(save.getId());
+        User testUser = userRepository.save(User.create("nickname", "defailt_profile_image"));
+        TokenPair tokenPair = jwtService.createToken(testUser.getId());
         System.out.println("accessToken = " + tokenPair.accessToken());
         System.out.println("refreshToken = " + tokenPair.refreshToken());
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            User user = userRepository.save(User.create("nickname" + i, "defailt_profile_image"));
+            users.add(user);
+            for (int j = 0; j < 30; j += 2) {
+                ImageFile imageFile1 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));
+                ImageFile imageFile2 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));
+                postRepository.save(Post.create(user.getId(), "description" + j, List.of(PostImage.create("뽀또A", imageFile1.getId()), PostImage.create("뽀또B", imageFile2.getId())), "https://photopic.site/shareurl"));
+            }
+        }
+        List<Post> posts = postRepository.findAll();
+        for (User user : users) {
+            for (Post post : posts) {
+                Random random = new Random();
+                int num = random.nextInt(2);
+                voteService.vote(user.getId(), post.getId(), post.getImages().get(num).getId());
+            }
+        }
     }
 }

--- a/src/main/java/com/swyp8team2/common/domain/BaseEntity.java
+++ b/src/main/java/com/swyp8team2/common/domain/BaseEntity.java
@@ -2,12 +2,14 @@ package com.swyp8team2.common.domain;
 
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseEntity {

--- a/src/main/java/com/swyp8team2/common/exception/ApplicationControllerAdvice.java
+++ b/src/main/java/com/swyp8team2/common/exception/ApplicationControllerAdvice.java
@@ -7,6 +7,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import javax.naming.AuthenticationException;
@@ -44,6 +45,12 @@ public class ApplicationControllerAdvice {
     @ExceptionHandler(NoResourceFoundException.class)
     public ResponseEntity<ErrorResponse> handle(NoResourceFoundException e) {
         return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ErrorResponse> handle(HandlerMethodValidationException e) {
+        return ResponseEntity.badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_ARGUMENT));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE("잘못된 입력 값"),
     SOCIAL_AUTHENTICATION_FAILED("소셜 로그인 실패"),
     POST_IMAGE_NAME_GENERATOR_INDEX_OUT_OF_BOUND("이미지 이름 생성기 인덱스 초과"),
+    IMAGE_FILE_NOT_FOUND("존재하지 않는 이미지"),
 
     //503
     SERVICE_UNAVAILABLE("서비스 이용 불가"),

--- a/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     SOCIAL_AUTHENTICATION_FAILED("소셜 로그인 실패"),
     POST_IMAGE_NAME_GENERATOR_INDEX_OUT_OF_BOUND("이미지 이름 생성기 인덱스 초과"),
     IMAGE_FILE_NOT_FOUND("존재하지 않는 이미지"),
+    POST_IMAGE_NOT_FOUND("게시글 이미지 없음"),
 
     //503
     SERVICE_UNAVAILABLE("서비스 이용 불가"),

--- a/src/main/java/com/swyp8team2/post/application/PostService.java
+++ b/src/main/java/com/swyp8team2/post/application/PostService.java
@@ -1,14 +1,20 @@
 package com.swyp8team2.post.application;
 
+import com.swyp8team2.common.exception.BadRequestException;
+import com.swyp8team2.common.exception.ErrorCode;
 import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostImage;
 import com.swyp8team2.post.domain.PostRepository;
 import com.swyp8team2.post.presentation.dto.CreatePostRequest;
+import com.swyp8team2.post.presentation.dto.PostResponse;
+import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Service
@@ -34,5 +40,23 @@ public class PostService {
                         nameGenerator.generate(),
                         voteRequestDto.imageFileId()
                 )).toList();
+    }
+
+    public PostResponse find(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND));
+        User user = userRepository.findById(post.getUserId())
+                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+        List<PostImage> images = post.getImages();
+        int totalVoteCount = 0;
+        for (PostImage image : images) {
+            totalVoteCount += image.getVoteCount();
+        }
+        BigDecimal totalCount = new BigDecimal(totalVoteCount);
+        for (PostImage image : images) {
+            BigDecimal voteCount = new BigDecimal(image.getVoteCount());
+            String voteRatio = voteCount.divide(totalCount, 2, RoundingMode.HALF_UP).toString();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/swyp8team2/post/application/RatioCalculator.java
+++ b/src/main/java/com/swyp8team2/post/application/RatioCalculator.java
@@ -1,0 +1,18 @@
+package com.swyp8team2.post.application;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class RatioCalculator {
+
+    public String calculateRatio(int totalVoteCount, int voteCount) {
+        if (totalVoteCount == 0) {
+            return "0.0";
+        }
+        BigDecimal totalCount = new BigDecimal(totalVoteCount);
+        BigDecimal count = new BigDecimal(voteCount);
+        BigDecimal bigDecimal = count.divide(totalCount, 3, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal(100));
+        return String.format("%.1f", bigDecimal);
+    }
+}

--- a/src/main/java/com/swyp8team2/post/application/RatioCalculator.java
+++ b/src/main/java/com/swyp8team2/post/application/RatioCalculator.java
@@ -1,8 +1,11 @@
 package com.swyp8team2.post.application;
 
+import org.springframework.stereotype.Component;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+@Component
 public class RatioCalculator {
 
     public String calculateRatio(int totalVoteCount, int voteCount) {

--- a/src/main/java/com/swyp8team2/post/domain/Post.java
+++ b/src/main/java/com/swyp8team2/post/domain/Post.java
@@ -15,6 +15,7 @@ import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -24,6 +25,7 @@ import static com.swyp8team2.common.util.Validator.*;
 
 @Getter
 @Entity
+@ToString(exclude = "images")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
@@ -44,8 +46,6 @@ public class Post extends BaseEntity {
     private String shareUrl;
 
     public Post(Long id, Long userId, String description, State state, List<PostImage> images, String shareUrl) {
-        validateNull(userId, state, description, images);
-        validateEmptyString(shareUrl);
         validateDescription(description);
         validatePostImages(images);
         this.id = id;
@@ -76,6 +76,22 @@ public class Post extends BaseEntity {
     public PostImage getBestPickedImage() {
         return images.stream()
                 .max(Comparator.comparing(PostImage::getVoteCount))
-                .orElseThrow(() -> new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR));
+                .orElseThrow(() -> new InternalServerException(ErrorCode.POST_IMAGE_NOT_FOUND));
+    }
+
+    public void vote(Long imageId) {
+        PostImage image = images.stream()
+                .filter(postImage -> postImage.getId().equals(imageId))
+                .findFirst()
+                .orElseThrow(() -> new InternalServerException(ErrorCode.POST_IMAGE_NOT_FOUND));
+        image.increaseVoteCount();
+    }
+
+    public void cancelVote(Long imageId) {
+        PostImage image = images.stream()
+                .filter(postImage -> postImage.getId().equals(imageId))
+                .findFirst()
+                .orElseThrow(() -> new InternalServerException(ErrorCode.POST_IMAGE_NOT_FOUND));
+        image.decreaseVoteCount();
     }
 }

--- a/src/main/java/com/swyp8team2/post/domain/Post.java
+++ b/src/main/java/com/swyp8team2/post/domain/Post.java
@@ -3,6 +3,7 @@ package com.swyp8team2.post.domain;
 import com.swyp8team2.common.domain.BaseEntity;
 import com.swyp8team2.common.exception.BadRequestException;
 import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.common.exception.InternalServerException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -16,6 +17,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static com.swyp8team2.common.util.Validator.*;
@@ -69,5 +71,11 @@ public class Post extends BaseEntity {
 
     public static Post create(Long userId, String description, List<PostImage> images, String shareUrl) {
         return new Post(null, userId, description, State.PROGRESS, images, shareUrl);
+    }
+
+    public PostImage getBestPickedImage() {
+        return images.stream()
+                .max(Comparator.comparing(PostImage::getVoteCount))
+                .orElseThrow(() -> new InternalServerException(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/swyp8team2/post/domain/PostImage.java
+++ b/src/main/java/com/swyp8team2/post/domain/PostImage.java
@@ -32,8 +32,6 @@ public class PostImage {
     private int voteCount;
 
     public PostImage(Long id, Post post, String name, Long imageFileId, int voteCount) {
-        validateNull(post, imageFileId);
-        validateEmptyString(name);
         this.id = id;
         this.post = post;
         this.name = name;
@@ -42,8 +40,6 @@ public class PostImage {
     }
 
     public PostImage(String name, Long imageFileId, int voteCount) {
-        validateNull(imageFileId);
-        validateEmptyString(name);
         this.name = name;
         this.imageFileId = imageFileId;
         this.voteCount = voteCount;
@@ -56,5 +52,13 @@ public class PostImage {
     public void setPost(Post post) {
         validateNull(post);
         this.post = post;
+    }
+
+    public void increaseVoteCount() {
+        this.voteCount++;
+    }
+
+    public void decreaseVoteCount() {
+        this.voteCount = this.voteCount == 0 ? 0 : this.voteCount - 1;
     }
 }

--- a/src/main/java/com/swyp8team2/post/domain/PostRepository.java
+++ b/src/main/java/com/swyp8team2/post/domain/PostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
@@ -21,4 +21,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             """
     )
     Slice<Post> findByUserId(@Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
+
+    @Query("""
+            SELECT p
+            FROM Post p
+            WHERE p.id IN :postIds
+            AND (:postId IS NULL OR p.id < :postId)
+            ORDER BY p.createdAt DESC
+            """
+    )
+    Slice<Post> findByIdIn(@Param("postIds") List<Long> postIds, @Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/com/swyp8team2/post/domain/PostRepository.java
+++ b/src/main/java/com/swyp8team2/post/domain/PostRepository.java
@@ -1,8 +1,24 @@
 package com.swyp8team2.post.domain;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Query("""
+            SELECT p
+            FROM Post p
+            WHERE p.userId = :userId
+            AND (:postId IS NULL OR p.id < :postId)
+            ORDER BY p.createdAt DESC
+            """
+    )
+    Slice<Post> findByUserId(@Param("userId") Long userId, @Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -82,17 +82,6 @@ public class PostController {
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        return ResponseEntity.ok(new CursorBasePaginatedResponse<>(
-                1L,
-                false,
-                List.of(
-                        new SimplePostResponse(
-                                1L,
-                                "https://image.photopic.site/1",
-                                "https://photopic.site/shareurl",
-                                LocalDateTime.of(2025, 2, 13, 12, 0)
-                        )
-                )
-        ));
+        return ResponseEntity.ok(postService.findVotedPosts(userInfo.userId(), cursor, size));
     }
 }

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -51,8 +51,8 @@ public class PostController {
                 ),
                 "description",
                 List.of(
-                        new VoteResponseDto(1L, "https://image.photopic.site/1", 62.75, true),
-                        new VoteResponseDto(2L, "https://image.photopic.site/2", 37.25, false)
+                        new VoteResponseDto(1L, "https://image.photopic.site/1", 3, "60.0", true),
+                        new VoteResponseDto(2L, "https://image.photopic.site/2", 2, "40.0", false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -9,6 +9,7 @@ import com.swyp8team2.post.presentation.dto.PostResponse;
 import com.swyp8team2.post.presentation.dto.SimplePostResponse;
 import com.swyp8team2.post.presentation.dto.VoteResponseDto;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -69,8 +70,8 @@ public class PostController {
 
     @GetMapping("/me")
     public ResponseEntity<CursorBasePaginatedResponse<SimplePostResponse>> findMyPosts(
-            @RequestParam(name = "cursor", required = false) Long cursor,
-            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "cursor", required = false) @Min(0) Long cursor,
+            @RequestParam(name = "size", required = false, defaultValue = "10") @Min(1) int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
         return ResponseEntity.ok(postService.findMyPosts(userInfo.userId(), cursor, size));
@@ -78,8 +79,8 @@ public class PostController {
 
     @GetMapping("/voted")
     public ResponseEntity<CursorBasePaginatedResponse<SimplePostResponse>> findVotedPosts(
-            @RequestParam(name = "cursor", required = false) Long cursor,
-            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "cursor", required = false) @Min(0) Long cursor,
+            @RequestParam(name = "size", required = false, defaultValue = "10") @Min(1) int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
         return ResponseEntity.ok(postService.findVotedPosts(userInfo.userId(), cursor, size));

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -73,18 +73,7 @@ public class PostController {
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        return ResponseEntity.ok(new CursorBasePaginatedResponse<>(
-                1L,
-                false,
-                List.of(
-                        new SimplePostResponse(
-                                1L,
-                                "https://image.photopic.site/1",
-                                "https://photopic.site/shareurl",
-                                LocalDateTime.of(2025, 2, 13, 12, 0)
-                        )
-                )
-        ));
+        return ResponseEntity.ok(postService.findMyPosts(userInfo.userId(), cursor, size));
     }
 
     @GetMapping("/voted")

--- a/src/main/java/com/swyp8team2/post/presentation/dto/AuthorDto.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/AuthorDto.java
@@ -1,8 +1,17 @@
 package com.swyp8team2.post.presentation.dto;
 
+import com.swyp8team2.user.domain.User;
+
 public record AuthorDto(
         Long id,
         String nickname,
         String profileUrl
 ) {
+    public static AuthorDto of(User user) {
+        return new AuthorDto(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileUrl()
+        );
+    }
 }

--- a/src/main/java/com/swyp8team2/post/presentation/dto/PostResponse.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/PostResponse.java
@@ -1,5 +1,8 @@
 package com.swyp8team2.post.presentation.dto;
 
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.user.domain.User;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,4 +14,14 @@ public record PostResponse(
         String shareUrl,
         LocalDateTime createdAt
 ) {
+    public static PostResponse of(Post post, User user, List<VoteResponseDto> votes) {
+        return new PostResponse(
+                post.getId(),
+                AuthorDto.of(user),
+                post.getDescription(),
+                votes,
+                post.getShareUrl(),
+                post.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/swyp8team2/post/presentation/dto/SimplePostResponse.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/SimplePostResponse.java
@@ -1,6 +1,7 @@
 package com.swyp8team2.post.presentation.dto;
 
 import com.swyp8team2.common.dto.CursorDto;
+import com.swyp8team2.post.domain.Post;
 
 import java.time.LocalDateTime;
 
@@ -10,6 +11,15 @@ public record SimplePostResponse(
         String shareUrl,
         LocalDateTime createdAt
 ) implements CursorDto {
+
+    public static SimplePostResponse of(Post post, String bestPickedImageUrl) {
+        return new SimplePostResponse(
+                post.getId(),
+                bestPickedImageUrl,
+                post.getShareUrl(),
+                post.getCreatedAt()
+        );
+    }
 
     @Override
     public long getId() {

--- a/src/main/java/com/swyp8team2/post/presentation/dto/VoteResponseDto.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/VoteResponseDto.java
@@ -3,7 +3,8 @@ package com.swyp8team2.post.presentation.dto;
 public record VoteResponseDto(
         Long id,
         String imageUrl,
-        double voteRatio,
+        int voteCount,
+        String voteRatio,
         boolean voted
 ) {
 }

--- a/src/main/java/com/swyp8team2/user/domain/User.java
+++ b/src/main/java/com/swyp8team2/user/domain/User.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 import static com.swyp8team2.common.util.Validator.validateEmptyString;
 import static com.swyp8team2.common.util.Validator.validateNull;
 
@@ -25,15 +27,18 @@ public class User {
 
     private String profileUrl;
 
-    public User(Long id, String nickname, String profileUrl) {
+    private String seq;
+
+    public User(Long id, String nickname, String profileUrl, String seq) {
         validateNull(nickname, profileUrl);
         validateEmptyString(nickname, profileUrl);
         this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;
+        this.seq = seq;
     }
 
     public static User create(String nickname, String profileUrl) {
-        return new User(null, nickname, profileUrl);
+        return new User(null, nickname, profileUrl, UUID.randomUUID().toString());
     }
 }

--- a/src/main/java/com/swyp8team2/vote/application/VoteService.java
+++ b/src/main/java/com/swyp8team2/vote/application/VoteService.java
@@ -1,0 +1,47 @@
+package com.swyp8team2.vote.application;
+
+import com.swyp8team2.common.exception.BadRequestException;
+import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.user.domain.User;
+import com.swyp8team2.user.domain.UserRepository;
+import com.swyp8team2.vote.domain.Vote;
+import com.swyp8team2.vote.domain.VoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class VoteService {
+
+    private final VoteRepository voteRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Long vote(Long userId, Long postId, Long imageId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+        voteRepository.findByUserSeqAndPostId(user.getSeq(), postId)
+                        .ifPresent(vote -> deleteExistingVote(postId, vote));
+        Vote vote = createVote(postId, imageId, user);
+        return vote.getId();
+    }
+
+    private Vote createVote(Long postId, Long imageId, User user) {
+        Vote vote = voteRepository.save(Vote.of(postId, imageId, user.getSeq()));
+        postRepository.findById(postId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND))
+                .vote(imageId);
+        return vote;
+    }
+
+    private void deleteExistingVote(Long postId, Vote vote) {
+        voteRepository.delete(vote);
+        postRepository.findById(postId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND))
+                .cancelVote(vote.getPostImageId());
+    }
+}

--- a/src/main/java/com/swyp8team2/vote/domain/Vote.java
+++ b/src/main/java/com/swyp8team2/vote/domain/Vote.java
@@ -1,0 +1,38 @@
+package com.swyp8team2.vote.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "user_votes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vote {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long postId;
+
+    private Long postImageId;
+
+    private String userSeq;
+
+    public Vote(Long id, Long postId, Long postImageId, String userSeq) {
+        this.id = id;
+        this.postId = postId;
+        this.postImageId = postImageId;
+        this.userSeq = userSeq;
+    }
+
+    public static Vote of(Long postId, Long postImageId, String userSeq) {
+        return new Vote(null, postId, postImageId, userSeq);
+    }
+}

--- a/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
+++ b/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
@@ -1,0 +1,14 @@
+package com.swyp8team2.vote.domain;
+
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    Optional<Vote> findByUserSeqAndPostId(String userSeq, Long postId);
+
+    Slice<Vote> findByUserSeq(String seq);
+}

--- a/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
+++ b/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
@@ -2,6 +2,7 @@ package com.swyp8team2.vote.presentation;
 
 import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.common.presentation.CustomHeader;
+import com.swyp8team2.vote.application.VoteService;
 import com.swyp8team2.vote.presentation.dto.ChangeVoteRequest;
 import com.swyp8team2.vote.presentation.dto.GuestVoteRequest;
 import com.swyp8team2.vote.presentation.dto.VoteRequest;
@@ -24,12 +25,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/posts/{postId}/votes")
 public class VoteController {
 
+    private final VoteService voteService;
+
     @PostMapping("")
     public ResponseEntity<Void> vote(
             @PathVariable("postId") Long postId,
             @Valid @RequestBody VoteRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
+        voteService.vote(userInfo.userId(), postId, request.voteId());
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
+++ b/src/test/java/com/swyp8team2/comment/application/CommentServiceTest.java
@@ -69,7 +69,7 @@ class CommentServiceTest {
         Comment comment1 = new Comment(1L, postId, 100L, "첫 번째 댓글");
         Comment comment2 = new Comment(2L, postId, 100L, "두 번째 댓글");
         SliceImpl<Comment> commentSlice = new SliceImpl<>(List.of(comment1, comment2), PageRequest.of(0, size), false);
-        User user = new User(100L, "닉네임","http://example.com/profile.png");
+        User user = new User(100L, "닉네임","http://example.com/profile.png", "seq");
 
         // Mock 설정
         given(commentRepository.findByPostId(eq(postId), eq(cursor), any(PageRequest.class))).willReturn(commentSlice);

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.swyp8team2.comment.domain;
 
+import com.swyp8team2.support.RepositoryTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
@@ -11,8 +11,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-class CommentRepositoryTest {
+class CommentRepositoryTest extends RepositoryTest {
 
     @Autowired
     private CommentRepository commentRepository;

--- a/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
+++ b/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
@@ -16,6 +16,8 @@ import com.swyp8team2.post.presentation.dto.VoteResponseDto;
 import com.swyp8team2.support.IntegrationTest;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
+import com.swyp8team2.vote.domain.Vote;
+import com.swyp8team2.vote.domain.VoteRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +25,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.swyp8team2.support.fixture.FixtureGenerator.createImageFile;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createPost;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,6 +45,9 @@ class PostServiceTest extends IntegrationTest {
 
     @Autowired
     ImageFileRepository imageFileRepository;
+
+    @Autowired
+    VoteRepository voteRepository;
 
     @Test
     @DisplayName("게시글 작성")
@@ -105,10 +113,10 @@ class PostServiceTest extends IntegrationTest {
     @DisplayName("게시글 조회")
     void findById() throws Exception {
         //given
-        User user = createUser(1);
-        ImageFile imageFile1 = createImageFile(1);
-        ImageFile imageFile2 = createImageFile(2);
-        Post post = createPost(user, imageFile1, imageFile2, 1);
+        User user = userRepository.save(createUser(1));
+        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
+        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
+        Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
 
         //when
         PostResponse response = postService.findById(post.getId());
@@ -137,13 +145,8 @@ class PostServiceTest extends IntegrationTest {
     @DisplayName("내가 작성한 게시글 조회 - 커서 null인 경우")
     void findMyPosts() throws Exception {
         //given
-        User user = createUser(1);
-        List<Post> posts = new ArrayList<>();
-        for (int i = 0; i < 30; i += 2) {
-            ImageFile imageFile1 = createImageFile(i);
-            ImageFile imageFile2 = createImageFile(i + 1);
-            posts.add(createPost(user, imageFile1, imageFile2, i));
-        }
+        User user = userRepository.save(createUser(1));
+        List<Post> posts = createPosts(user);
         int size = 10;
 
         //when
@@ -161,13 +164,8 @@ class PostServiceTest extends IntegrationTest {
     @DisplayName("내가 작성한 게시글 조회 - 커서 있는 경우")
     void findMyPosts2() throws Exception {
         //given
-        User user = createUser(1);
-        List<Post> posts = new ArrayList<>();
-        for (int i = 0; i < 30; i += 2) {
-            ImageFile imageFile1 = createImageFile(i);
-            ImageFile imageFile2 = createImageFile(i + 1);
-            posts.add(createPost(user, imageFile1, imageFile2, i));
-        }
+        User user = userRepository.save(createUser(1));
+        List<Post> posts = createPosts(user);
         int size = 10;
 
         //when
@@ -181,30 +179,37 @@ class PostServiceTest extends IntegrationTest {
         );
     }
 
-    private Post createPost(User user, ImageFile imageFile1, ImageFile imageFile2, int index) {
-        Post post = postRepository.save(Post.create(
-                user.getId(),
-                "description" + index,
-                List.of(
-                        PostImage.create("뽀또A", imageFile1.getId()),
-                        PostImage.create("뽀또B", imageFile2.getId())
-                ),
-                "shareUrl" + index
-        ));
-        return post;
+    private List<Post> createPosts(User user) {
+        List<Post> posts = new ArrayList<>();
+        for (int i = 0; i < 30; i += 2) {
+            ImageFile imageFile1 = imageFileRepository.save(createImageFile(i));
+            ImageFile imageFile2 = imageFileRepository.save(createImageFile(i + 1));
+            posts.add(postRepository.save(createPost(user.getId(), imageFile1, imageFile2, i)));
+        }
+        return posts;
     }
 
-    private User createUser(int index) {
-        return userRepository.save(User.create("nickname" + index, "profileUrl" + index));
-    }
+    @Test
+    @DisplayName("내가 투표한 게시글 조회 - 커서 null인 경우")
+    void findVotedPosts() throws Exception {
+        //given
+        User user = userRepository.save(createUser(1));
+        List<Post> posts = createPosts(user);
+        for (int i = 0; i < 15; i++) {
+            Post post = posts.get(i);
+            voteRepository.save(Vote.of(post.getId(), post.getImages().get(0).getId(), user.getSeq()));
+        }
+        int size = 10;
 
-    private ImageFile createImageFile(int index) {
-        return imageFileRepository.save(ImageFile.create(
-                new ImageFileDto(
-                        "originalFileName" + index,
-                        "imageUrl" + index,
-                        "thumbnailUrl" + index
-                )
-        ));
+        //when
+        var response = postService.findVotedPosts(user.getId(), null, size);
+
+        //then
+        int 전체_15개에서_맨_마지막_데이터_인덱스 = posts.size() - size;
+        assertAll(
+                () -> assertThat(response.data()).hasSize(size),
+                () -> assertThat(response.hasNext()).isTrue(),
+                () -> assertThat(response.nextCursor()).isEqualTo(posts.get(전체_15개에서_맨_마지막_데이터_인덱스).getId())
+        );
     }
 }

--- a/src/test/java/com/swyp8team2/post/application/RatioCalculatorTest.java
+++ b/src/test/java/com/swyp8team2/post/application/RatioCalculatorTest.java
@@ -1,0 +1,33 @@
+package com.swyp8team2.post.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RatioCalculatorTest {
+
+    RatioCalculator ratioCalculator;
+
+    @BeforeEach
+    void setUp() {
+        ratioCalculator = new RatioCalculator();
+    }
+
+    @ParameterizedTest(name = "{index}: totalVoteCount={0}, voteCount={1} => result={2}")
+    @CsvSource({"3, 2, 66.7", "3, 1, 33.3", "4, 2, 50.0", "4, 3, 75.0", "0, 0, 0.0", "1, 0, 0.0", "1, 1, 100.0"})
+    @DisplayName("비율 계산")
+    void calculate(int totalVoteCount, int voteCount, String result) throws Exception {
+        //given
+
+        //when
+        String ratio = ratioCalculator.calculateRatio(totalVoteCount, voteCount);
+
+        //then
+        assertThat(ratio).isEqualTo(result);
+    }
+}

--- a/src/test/java/com/swyp8team2/post/domain/PostImageTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostImageTest.java
@@ -1,11 +1,9 @@
 package com.swyp8team2.post.domain;
 
-import com.swyp8team2.common.exception.InternalServerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PostImageTest {
@@ -25,20 +23,6 @@ class PostImageTest {
                 () -> assertThat(postImage.getName()).isEqualTo(name),
                 () -> assertThat(postImage.getImageFileId()).isEqualTo(imageFileId),
                 () -> assertThat(postImage.getVoteCount()).isEqualTo(0)
-        );
-    }
-
-    @Test
-    @DisplayName("게시글 이미지 생성 - null 값이 들어온 경우")
-    void create_null() throws Exception {
-        //given
-
-        //when then
-        assertAll(
-                () -> assertThatThrownBy(() -> PostImage.create(null, 1L))
-                        .isInstanceOf(InternalServerException.class),
-                () -> assertThatThrownBy(() -> PostImage.create("뽀또A", null))
-                        .isInstanceOf(InternalServerException.class)
         );
     }
 }

--- a/src/test/java/com/swyp8team2/post/domain/PostRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostRepositoryTest.java
@@ -1,0 +1,96 @@
+package com.swyp8team2.post.domain;
+
+import com.swyp8team2.image.domain.ImageFile;
+import com.swyp8team2.support.RepositoryTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.swyp8team2.support.fixture.FixtureGenerator.createImageFile;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createPost;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostRepositoryTest extends RepositoryTest {
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Test
+    @DisplayName("유저가 작성한 게시글 조회 - 게시글이 15개일 경우 15번쨰부터 10개 조회해야 함")
+    void select_post_findByUserId1() throws Exception {
+        //given
+        long userId = 1L;
+        List<Post> posts = createPosts(userId);
+        int size = 10;
+
+        //when
+        Slice<Post> res = postRepository.findByUserId(userId, null, PageRequest.ofSize(size));
+
+        //then
+        assertAll(
+                () -> assertThat(res.getContent().size()).isEqualTo(size),
+                () -> assertThat(res.getContent().get(0).getId()).isEqualTo(posts.get(posts.size() - 1).getId()),
+                () -> assertThat(res.getContent().get(1).getId()).isEqualTo(posts.get(posts.size() - 2).getId()),
+                () -> assertThat(res.getContent().get(2).getId()).isEqualTo(posts.get(posts.size() - 3).getId()),
+                () -> assertThat(res.hasNext()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("유저가 작성한 게시글 조회 - 15개 중에 커서가 5번째 게시글의 id면 4번째부터 0번째까지 조회해야 함")
+    void select_post_findByUserId2() throws Exception {
+        //given
+        long userId = 1L;
+        List<Post> posts = createPosts(userId);
+        int size = 10;
+        int cursorIndex = 5;
+
+        //when
+        Slice<Post> res = postRepository.findByUserId(userId, posts.get(cursorIndex).getId(), PageRequest.ofSize(size));
+
+        //then
+        assertAll(
+                () -> assertThat(res.getContent().size()).isEqualTo(5),
+                () -> assertThat(res.getContent().get(0).getId()).isEqualTo(posts.get(cursorIndex - 1).getId()),
+                () -> assertThat(res.getContent().get(1).getId()).isEqualTo(posts.get(cursorIndex - 2).getId()),
+                () -> assertThat(res.getContent().get(2).getId()).isEqualTo(posts.get(cursorIndex - 3).getId()),
+                () -> assertThat(res.hasNext()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("id 리스트에 포함되는 게시글 조회")
+    void select_post_findByIdIn() throws Exception {
+        //given
+        List<Post> posts = createPosts(1L);
+        List<Long> postIds = List.of(posts.get(0).getId(), posts.get(1).getId(), posts.get(2).getId());
+
+        //when
+        Slice<Post> postSlice = postRepository.findByIdIn(postIds, null, PageRequest.ofSize(10));
+
+        //then
+        assertAll(
+                () -> assertThat(postSlice.getContent().size()).isEqualTo(postIds.size()),
+                () -> assertThat(postSlice.getContent().get(0).getId()).isEqualTo(postIds.get(2)),
+                () -> assertThat(postSlice.getContent().get(1).getId()).isEqualTo(postIds.get(1)),
+                () -> assertThat(postSlice.getContent().get(2).getId()).isEqualTo(postIds.get(0)),
+                () -> assertThat(postSlice.hasNext()).isFalse()
+        );
+    }
+
+    private List<Post> createPosts(long userId) {
+        List<Post> posts = new ArrayList<>();
+        for (int i = 0; i < 30; i += 2) {
+            ImageFile imageFile1 = createImageFile(i);
+            ImageFile imageFile2 = createImageFile(i + 1);
+            posts.add(postRepository.save(createPost(userId, imageFile1, imageFile2, i)));
+        }
+        return posts;
+    }
+}

--- a/src/test/java/com/swyp8team2/post/domain/PostTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostTest.java
@@ -75,26 +75,4 @@ class PostTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED.getMessage());
     }
-
-    @Test
-    @DisplayName("게시글 생성 - null 값이 들어오는 경우")
-    void create_null() throws Exception {
-        //given
-
-        //when then
-        assertAll(
-                () -> assertThatThrownBy(() -> Post.create(null, "description", List.of(), "shareUrl"))
-                        .isInstanceOf(InternalServerException.class)
-                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
-                () -> assertThatThrownBy(() -> Post.create(1L, null, List.of(), "shareUrl"))
-                        .isInstanceOf(InternalServerException.class)
-                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
-                () -> assertThatThrownBy(() -> Post.create(1L, "description", List.of(), null))
-                        .isInstanceOf(InternalServerException.class)
-                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage()),
-                () -> assertThatThrownBy(() -> Post.create(1L, "description", null, "shareUrl"))
-                        .isInstanceOf(InternalServerException.class)
-                        .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage())
-        );
-    }
 }

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -81,8 +81,8 @@ class PostControllerTest extends RestDocsTest {
                 ),
                 "description",
                 List.of(
-                        new VoteResponseDto(1L, "https://image.photopic.site/1", 62.75, true),
-                        new VoteResponseDto(2L, "https://image.photopic.site/2", 37.25, false)
+                        new VoteResponseDto(1L, "https://image.photopic.site/1", 3, "60.0", true),
+                        new VoteResponseDto(2L, "https://image.photopic.site/2", 2, "40.0", false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)
@@ -106,7 +106,8 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("votes[]").type(JsonFieldType.ARRAY).description("투표 선택지 목록"),
                                 fieldWithPath("votes[].id").type(JsonFieldType.NUMBER).description("투표 선택지 Id"),
                                 fieldWithPath("votes[].imageUrl").type(JsonFieldType.STRING).description("투표 이미지"),
-                                fieldWithPath("votes[].voteRatio").type(JsonFieldType.NUMBER).description("득표 비율"),
+                                fieldWithPath("votes[].voteRatio").type(JsonFieldType.STRING).description("득표 비율"),
+                                fieldWithPath("votes[].voteCount").type(JsonFieldType.NUMBER).description("득표 수"),
                                 fieldWithPath("votes[].voted").type(JsonFieldType.BOOLEAN).description("투표 여부"),
                                 fieldWithPath("shareUrl").type(JsonFieldType.STRING).description("게시글 공유 URL"),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 시간")

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -138,7 +139,7 @@ class PostControllerTest extends RestDocsTest {
     @DisplayName("내가 작성한 게시글 조회")
     void findMyPost() throws Exception {
         //given
-        CursorBasePaginatedResponse<SimplePostResponse> response = new CursorBasePaginatedResponse<>(
+        var response = new CursorBasePaginatedResponse<>(
                 1L,
                 false,
                 List.of(
@@ -150,6 +151,8 @@ class PostControllerTest extends RestDocsTest {
                         )
                 )
         );
+        given(postService.findMyPosts(1L, null, 10))
+                .willReturn(response);
 
         //when then
         mockMvc.perform(get("/posts/me")

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -194,7 +194,7 @@ class PostControllerTest extends RestDocsTest {
     @DisplayName("내가 참여한 게시글 조회")
     void findVotedPost() throws Exception {
         //given
-        CursorBasePaginatedResponse<SimplePostResponse> response = new CursorBasePaginatedResponse<>(
+        var response = new CursorBasePaginatedResponse<>(
                 1L,
                 false,
                 List.of(
@@ -206,6 +206,8 @@ class PostControllerTest extends RestDocsTest {
                         )
                 )
         );
+        given(postService.findVotedPosts(1L, null, 10))
+                .willReturn(response);
 
         //when then
         mockMvc.perform(get("/posts/voted")

--- a/src/test/java/com/swyp8team2/support/RepositoryTest.java
+++ b/src/test/java/com/swyp8team2/support/RepositoryTest.java
@@ -1,10 +1,10 @@
 package com.swyp8team2.support;
 
-import com.swyp8team2.common.config.CommonConfig;
+import com.swyp8team2.common.config.JpaConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(CommonConfig.class)
+@Import(JpaConfig.class)
 public abstract class RepositoryTest {
 }

--- a/src/test/java/com/swyp8team2/support/RepositoryTest.java
+++ b/src/test/java/com/swyp8team2/support/RepositoryTest.java
@@ -1,0 +1,10 @@
+package com.swyp8team2.support;
+
+import com.swyp8team2.common.config.CommonConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(CommonConfig.class)
+public abstract class RepositoryTest {
+}

--- a/src/test/java/com/swyp8team2/support/WebUnitTest.java
+++ b/src/test/java/com/swyp8team2/support/WebUnitTest.java
@@ -5,6 +5,7 @@ import com.swyp8team2.auth.application.AuthService;
 import com.swyp8team2.auth.presentation.RefreshTokenCookieGenerator;
 import com.swyp8team2.image.application.ImageService;
 import com.swyp8team2.post.application.PostService;
+import com.swyp8team2.vote.application.VoteService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -32,4 +33,7 @@ public abstract class WebUnitTest {
 
     @MockitoBean
     protected PostService postService;
+
+    @MockitoBean
+    protected VoteService voteService;
 }

--- a/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
+++ b/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
@@ -1,0 +1,38 @@
+package com.swyp8team2.support.fixture;
+
+import com.swyp8team2.image.domain.ImageFile;
+import com.swyp8team2.image.presentation.dto.ImageFileDto;
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.post.domain.PostImage;
+import com.swyp8team2.user.domain.User;
+
+import java.util.List;
+
+public abstract class FixtureGenerator {
+
+    public static Post createPost(Long userId, ImageFile imageFile1, ImageFile imageFile2, int key) {
+        return Post.create(
+                userId,
+                "description" + key,
+                List.of(
+                        PostImage.create("뽀또A", imageFile1.getId()),
+                        PostImage.create("뽀또B", imageFile2.getId())
+                ),
+                "shareUrl" + key
+        );
+    }
+
+    public static User createUser(int key) {
+        return User.create("nickname" + key, "profileUrl" + key);
+    }
+
+    public static ImageFile createImageFile(int key) {
+        return ImageFile.create(
+                new ImageFileDto(
+                        "originalFileName" + key,
+                        "imageUrl" + key,
+                        "thumbnailUrl" + key
+                )
+        );
+    }
+}

--- a/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
+++ b/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
@@ -1,0 +1,86 @@
+package com.swyp8team2.vote.application;
+
+import com.swyp8team2.image.domain.ImageFile;
+import com.swyp8team2.image.domain.ImageFileRepository;
+import com.swyp8team2.post.domain.Post;
+import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.support.IntegrationTest;
+import com.swyp8team2.user.domain.User;
+import com.swyp8team2.user.domain.UserRepository;
+import com.swyp8team2.vote.domain.Vote;
+import com.swyp8team2.vote.domain.VoteRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.swyp8team2.support.fixture.FixtureGenerator.createImageFile;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createPost;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VoteServiceTest extends IntegrationTest {
+
+    @Autowired
+    VoteService voteService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    VoteRepository voteRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    ImageFileRepository imageFileRepository;
+
+    @Test
+    @DisplayName("투표하기")
+    void vote() {
+        // given
+        User user = userRepository.save(createUser(1));
+        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
+        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
+        Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
+
+        // when
+        Long voteId = voteService.vote(user.getId(), post.getId(), post.getImages().get(0).getId());
+
+        // then
+        Vote vote = voteRepository.findById(voteId).get();
+        Post findPost = postRepository.findById(post.getId()).get();
+        assertAll(
+                () -> assertThat(vote.getUserSeq()).isEqualTo(user.getSeq()),
+                () -> assertThat(vote.getPostId()).isEqualTo(post.getId()),
+                () -> assertThat(vote.getPostImageId()).isEqualTo(post.getImages().get(0).getId()),
+                () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    @DisplayName("투표하기 - 다른 이미지로 투표 변경한 경우")
+    void vote_change() {
+        // given
+        User user = userRepository.save(createUser(1));
+        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
+        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
+        Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
+        voteService.vote(user.getId(), post.getId(), post.getImages().get(0).getId());
+
+        // when
+        Long voteId = voteService.vote(user.getId(), post.getId(), post.getImages().get(1).getId());
+
+        // then
+        Vote vote = voteRepository.findById(voteId).get();
+        Post findPost = postRepository.findById(post.getId()).get();
+        assertAll(
+                () -> assertThat(vote.getUserSeq()).isEqualTo(user.getSeq()),
+                () -> assertThat(vote.getPostId()).isEqualTo(post.getId()),
+                () -> assertThat(vote.getPostImageId()).isEqualTo(post.getImages().get(1).getId()),
+                () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(0),
+                () -> assertThat(findPost.getImages().get(1).getVoteCount()).isEqualTo(1)
+        );
+    }
+}


### PR DESCRIPTION
## 🚀 작업 내용 설명

- 내가 투표한 게시글 조회
- 내가 작성한 게시글 조회
- 투표하기 (게스트 투표 미구현)
  - 동시성 고려 x
- 더미 데이터 추가

## 📢 그 외

투표 변경은 투표하기 기능으로 합쳤습니다.

id로 게시글 조회 기능은 투표 현황 API 분리해야 돼서 수정이 필요해서 추가 구현 필요한 상황이고, docs에 테스트용 access token 추가하고 API 이름 옆에 Http Method 추가했습니다.

## 📌  관련 이슈

#1 #2 #28