### PR TITLE
fix: CRC32 헤더 비활성화 설정 추가

### DIFF
--- a/src/main/java/com/swyp8team2/image/config/S3Config.java
+++ b/src/main/java/com/swyp8team2/image/config/S3Config.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -33,6 +35,8 @@ public class S3Config {
                 .serviceConfiguration(S3Configuration.builder()
                         .pathStyleAccessEnabled(true)
                         .build())
+                .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+                .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
                 .build();
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용 설명
- S3Config 수정

## 📢 그 외
### 문제
- R2 스토리지가 AWS S3 API와 호환되도록 지원하지만, 일부 호환이 안되는 문제들이 있음

### 원인
- R2 스토리지는 x-amz-checksum-crc32 헤더에 대해 지원을 안함
- 해당 헤더는 S3에 객체를 업로드할 때, 데이터 무결성 확인을 위해 사용하는 헤더임

### 해결방법
- SDK가 필요할 때만 체크섬을 검증하도록 S3Client 설정 값 수정
  - requestChecksumCalculation
  - responseChecksumValidation

## 📌 관련 이슈
close #45 