### PR TITLE
Feature/user nickname

### DIFF
--- a/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
+++ b/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
@@ -8,10 +8,11 @@ import com.swyp8team2.image.presentation.dto.ImageFileDto;
 import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostImage;
 import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.user.domain.NicknameAdjective;
+import com.swyp8team2.user.domain.NicknameAdjectiveRepository;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
 import com.swyp8team2.vote.application.VoteService;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class DataInitializer {
 
+    private final NicknameAdjectiveRepository nicknameAdjectiveRepository;
     private final UserRepository userRepository;
     private final ImageFileRepository imageFileRepository;
     private final PostRepository postRepository;
@@ -34,13 +36,14 @@ public class DataInitializer {
 
     @Transactional
     public void init() {
+        List<NicknameAdjective> adjectives = nicknameAdjectiveRepository.findAll();
         User testUser = userRepository.save(User.create("nickname", "defailt_profile_image"));
         TokenPair tokenPair = jwtService.createToken(testUser.getId());
         System.out.println("accessToken = " + tokenPair.accessToken());
         System.out.println("refreshToken = " + tokenPair.refreshToken());
         List<User> users = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            User user = userRepository.save(User.create("nickname" + i, "defailt_profile_image"));
+            User user = userRepository.save(User.create(adjectives.get(i).getAdjective(), "defailt_profile_image"));
             users.add(user);
             for (int j = 0; j < 30; j += 2) {
                 ImageFile imageFile1 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));

--- a/src/main/java/com/swyp8team2/user/application/UserService.java
+++ b/src/main/java/com/swyp8team2/user/application/UserService.java
@@ -2,6 +2,8 @@ package com.swyp8team2.user.application;
 
 import com.swyp8team2.common.exception.BadRequestException;
 import com.swyp8team2.common.exception.ErrorCode;
+import com.swyp8team2.user.domain.NicknameAdjective;
+import com.swyp8team2.user.domain.NicknameAdjectiveRepository;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
 import com.swyp8team2.user.presentation.dto.UserInfoResponse;
@@ -17,6 +19,7 @@ import java.util.Optional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final NicknameAdjectiveRepository nicknameAdjectiveRepository;
 
     @Transactional
     public Long createUser(String nickname, String profileImageUrl) {
@@ -29,9 +32,14 @@ public class UserService {
                 .orElse("defailt_profile_image");
     }
 
-    private String getNickname(String email) {
-        return Optional.ofNullable(email)
-                .orElseGet(() -> "user_" + System.currentTimeMillis());
+    private String getNickname(String nickname) {
+        return Optional.ofNullable(nickname)
+                .orElseGet(() -> {
+                    long randomIndex = (long)(Math.random() * 500);
+                    Optional<NicknameAdjective> adjective = nicknameAdjectiveRepository.findNicknameAdjectiveById(randomIndex);
+                    return adjective.map(NicknameAdjective::getAdjective)
+                            .orElse("user_" + System.currentTimeMillis());
+                });
     }
 
     public UserInfoResponse findById(Long userId) {

--- a/src/main/java/com/swyp8team2/user/domain/NicknameAdjective.java
+++ b/src/main/java/com/swyp8team2/user/domain/NicknameAdjective.java
@@ -1,0 +1,26 @@
+package com.swyp8team2.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.GenerationType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "nickname_adjectives")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class NicknameAdjective {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String adjective;
+
+    public NicknameAdjective(String adjective) {
+        this.adjective = adjective;
+    }
+}

--- a/src/main/java/com/swyp8team2/user/domain/NicknameAdjectiveRepository.java
+++ b/src/main/java/com/swyp8team2/user/domain/NicknameAdjectiveRepository.java
@@ -1,0 +1,12 @@
+package com.swyp8team2.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NicknameAdjectiveRepository extends JpaRepository<NicknameAdjective, Long> {
+
+    Optional<NicknameAdjective> findNicknameAdjectiveById(Long id);
+}

--- a/src/main/java/com/swyp8team2/user/domain/User.java
+++ b/src/main/java/com/swyp8team2/user/domain/User.java
@@ -30,8 +30,6 @@ public class User {
     private String seq;
 
     public User(Long id, String nickname, String profileUrl, String seq) {
-        validateNull(nickname, profileUrl);
-        validateEmptyString(nickname, profileUrl);
         this.id = id;
         this.nickname = nickname;
         this.profileUrl = profileUrl;

--- a/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
+++ b/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class UserServiceTest {
+  
+}

--- a/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
+++ b/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
@@ -1,4 +1,46 @@
-import static org.junit.jupiter.api.Assertions.*;
-class UserServiceTest {
-  
+package com.swyp8team2.user.application;
+
+import com.swyp8team2.support.IntegrationTest;
+import com.swyp8team2.user.domain.NicknameAdjective;
+import com.swyp8team2.user.domain.NicknameAdjectiveRepository;
+import com.swyp8team2.user.domain.User;
+import com.swyp8team2.user.domain.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class UserServiceTest extends IntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    NicknameAdjectiveRepository nicknameAdjectiveRepository;
+
+    @Autowired
+    UserService userService;
+
+    @Test
+    void createUser() {
+        // given
+        User user = User.create(null, "https://image.com/1");
+        // 메인 코드에서는 2개만 수정 후 테스트 진행
+        nicknameAdjectiveRepository.save(new NicknameAdjective("호기심 많은 뽀또"));
+        nicknameAdjectiveRepository.save(new NicknameAdjective("배려 깊은 뽀또"));
+
+        // when
+        Long userId = userService.createUser(user.getNickname(), user.getProfileUrl());
+        Optional<User> returnUser = userRepository.findById(userId);
+
+        // when then
+        assertAll(
+                () -> assertThat(returnUser.get().getNickname()).isNotNull(),
+                () -> assertThat(returnUser.get().getNickname()).contains("뽀또")
+        );
+
+    }
 }

--- a/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
+++ b/src/test/java/com/swyp8team2/user/application/UserServiceTest.java
@@ -28,9 +28,11 @@ class UserServiceTest extends IntegrationTest {
     void createUser() {
         // given
         User user = User.create(null, "https://image.com/1");
-        // 메인 코드에서는 2개만 수정 후 테스트 진행
-        nicknameAdjectiveRepository.save(new NicknameAdjective("호기심 많은 뽀또"));
-        nicknameAdjectiveRepository.save(new NicknameAdjective("배려 깊은 뽀또"));
+
+        for (int i = 0; i < 250; i++) {
+            nicknameAdjectiveRepository.save(new NicknameAdjective("호기심 많은 뽀또"));
+            nicknameAdjectiveRepository.save(new NicknameAdjective("배려 깊은 뽀또"));
+        }
 
         // when
         Long userId = userService.createUser(user.getNickname(), user.getProfileUrl());

--- a/src/test/java/com/swyp8team2/user/domain/UserTest.java
+++ b/src/test/java/com/swyp8team2/user/domain/UserTest.java
@@ -1,12 +1,9 @@
 package com.swyp8team2.user.domain;
 
-import com.swyp8team2.common.exception.ErrorCode;
-import com.swyp8team2.common.exception.InternalServerException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserTest {
 
@@ -21,27 +18,5 @@ class UserTest {
 
         //then
         assertThat(user.getNickname()).isEqualTo(nickname);
-    }
-
-    @Test
-    @DisplayName("user Entity 생성 - 파라미터가 null인 경우")
-    void create_null() throws Exception {
-        //given
-
-        //when then
-        assertThatThrownBy(() -> User.create(null, "email"))
-                .isInstanceOf(InternalServerException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
-    }
-
-    @Test
-    @DisplayName("user Entity 생성 - nickname이 빈 문자인 경우")
-    void create_emptyString() throws Exception {
-        //given
-
-        //when then
-        assertThatThrownBy(() -> User.create("", "email"))
-                .isInstanceOf(InternalServerException.class)
-                .hasMessage(ErrorCode.INVALID_INPUT_VALUE.getMessage());
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용 설명
- User validate 제거
- NicknameAdjective 엔티티 생성
- 유저 생성 시 랜덤 닉네임 적용

## 📢 그 외
- 사전에 윤성님이 전달해준 500개의 닉네임 데이터 nickname_adjectives에 넣어둔 상태입니다
- 닉네임 적용 순서
  1. 카카오 닉네임 동의 시, 카카오 닉네임 적용
  2. 미동의 시, 형용사 데이터 중 랜덤 닉네임 적용
  3. 형용사 데이터 없는 경우 'user_{UUID}' 적용
- 추후 고려사항
  - 형용사 데이터가 500개라서 랜덤값을 0~499로 지정해놨는데 더 좋은 방법은 없을까
  - 이외의 리팩토링 요소 분석

## 📌 관련 이슈
#48 