### PR TITLE
Fix/post image response

### DIFF
--- a/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
+++ b/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
@@ -37,14 +37,14 @@ public class DataInitializer {
     @Transactional
     public void init() {
         List<NicknameAdjective> adjectives = nicknameAdjectiveRepository.findAll();
-        User testUser = userRepository.save(User.create("nickname", "defailt_profile_image"));
+        User testUser = userRepository.save(User.create("nickname", "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
         TokenPair tokenPair = jwtService.createToken(testUser.getId());
         System.out.println("accessToken = " + tokenPair.accessToken());
         System.out.println("refreshToken = " + tokenPair.refreshToken());
         List<User> users = new ArrayList<>();
         List<Post> posts = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
-            User user = userRepository.save(User.create(adjectives.get(i).getAdjective(), "defailt_profile_image"));
+            User user = userRepository.save(User.create(adjectives.get(i).getAdjective(), "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
             users.add(user);
             for (int j = 0; j < 30; j += 2) {
                 ImageFile imageFile1 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));

--- a/src/main/java/com/swyp8team2/post/application/PostService.java
+++ b/src/main/java/com/swyp8team2/post/application/PostService.java
@@ -79,6 +79,7 @@ public class PostService {
                 image.getId(),
                 image.getName(),
                 imageFile.getImageUrl(),
+                imageFile.getThumbnailUrl(),
                 voted
         );
     }

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -73,8 +73,8 @@ public class PostController {
                 ),
                 "description",
                 List.of(
-                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/1", true),
-                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/2", false)
+                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1",  true),
+                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/1", false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)

--- a/src/main/java/com/swyp8team2/post/presentation/dto/PostImageResponse.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/PostImageResponse.java
@@ -4,6 +4,7 @@ public record PostImageResponse(
         Long id,
         String imageName,
         String imageUrl,
+        String thumbnailUrl,
         boolean voted
 ) {
 }

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -86,8 +86,8 @@ class PostControllerTest extends RestDocsTest {
                 ),
                 "description",
                 List.of(
-                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/1", true),
-                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/2", false)
+                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1", true),
+                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/2", false)
                 ),
                 "https://photopic.site/shareurl",
                 LocalDateTime.of(2025, 2, 13, 12, 0)
@@ -114,6 +114,7 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("images[].id").type(JsonFieldType.NUMBER).description("투표 선택지 Id"),
                                 fieldWithPath("images[].imageName").type(JsonFieldType.STRING).description("사진 이름"),
                                 fieldWithPath("images[].imageUrl").type(JsonFieldType.STRING).description("사진 이미지"),
+                                fieldWithPath("images[].thumbnailUrl").type(JsonFieldType.STRING).description("확대 사진 이미지"),
                                 fieldWithPath("images[].voted").type(JsonFieldType.BOOLEAN).description("투표 여부"),
                                 fieldWithPath("shareUrl").type(JsonFieldType.STRING).description("게시글 공유 URL"),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 시간")


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 게시글 상세 조회 시 썸네일 이미지 URL도 불러오도록 추가
- 테스트 데이터 프로필 이미지 카카오 프로필 이미지로 세팅

## 📢 그 외
이상 없으면 확인 후에 직접 merge 부탁드립니다
죄송합니다

## 📌 관련 이슈
#57 