### PR TITLE
fix: 댓글 조회 순서 오름차순으로 수정

### DIFF
--- a/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
+++ b/src/main/java/com/swyp8team2/comment/domain/CommentRepository.java
@@ -14,8 +14,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             SELECT c
             FROM Comment c
             WHERE c.postId = :postId
-                AND (:cursor is null or c.id < :cursor)
-            ORDER BY c.createdAt DESC
+                AND (:cursor is null or c.id > :cursor)
+            ORDER BY c.createdAt ASC
             """)
     Slice<Comment> findByPostId(
             @Param("postId") Long postId,

--- a/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
+++ b/src/test/java/com/swyp8team2/comment/domain/CommentRepositoryTest.java
@@ -35,6 +35,6 @@ class CommentRepositoryTest extends RepositoryTest {
         Slice<Comment> result2 = commentRepository.findByPostId(1L, 1L, PageRequest.of(0, 10));
 
         // then2
-        assertThat(result2.getContent()).hasSize(0);
+        assertThat(result2.getContent()).hasSize(2);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 게시글 댓글 조회 정렬 수정

## 📢 그 외
- 내림차순 -> 오름차순

## 📌 관련 이슈
