### PR TITLE
Refactor/upload image

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,8 @@ dependencies {
 
     // image
     implementation 'software.amazon.awssdk:s3:2.30.18'
-    implementation 'org.imgscalr:imgscalr-lib:4.2'
-    implementation 'com.sksamuel.scrimage:scrimage-core:4.3.0'
-    implementation 'com.sksamuel.scrimage:scrimage-webp:4.3.0'
+    implementation 'software.amazon.awssdk:lambda:2.30.18'
+    implementation 'com.twelvemonkeys.imageio:imageio-webp:3.9.4'
 
     // gson
     implementation 'com.google.code.gson:gson:2.8.6'

--- a/src/main/java/com/swyp8team2/image/application/R2Storage.java
+++ b/src/main/java/com/swyp8team2/image/application/R2Storage.java
@@ -70,7 +70,7 @@ public class R2Storage {
                 file.transferTo(tempFile);
                 switch(fileExtension) {
                     case ".heic", ".heif" -> {
-                        convertHeicToWebp(tempFile, originFilename, realFileName);
+                        convertHeicToJpg(tempFile, originFilename, realFileName);
                     } case ".png", ".gif" -> {
                         metadata.put("Content-Type", "image/jpeg");
                         s3PutObject(convertToJpg(tempFile), realFileName, metadata);
@@ -92,7 +92,7 @@ public class R2Storage {
         }
     }
 
-    private void convertHeicToWebp(File sourceFile, String originFilename, String realFileName) throws IOException {
+    private void convertHeicToJpg(File sourceFile, String originFilename, String realFileName) throws IOException {
         byte[] fileContent = Files.readAllBytes(sourceFile.toPath());
         String base64Content = Base64.getEncoder().encodeToString(fileContent);
 

--- a/src/main/java/com/swyp8team2/image/config/S3Config.java
+++ b/src/main/java/com/swyp8team2/image/config/S3Config.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
 import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 
@@ -25,6 +26,12 @@ public class S3Config {
     @Value("${r2.endpoint}")
     private String endpoint;
 
+    @Value("${aws.access-key}")
+    private String awsAccessKey;
+
+    @Value("${aws.secret-key}")
+    private String awsSecretKey;
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
@@ -37,6 +44,14 @@ public class S3Config {
                         .build())
                 .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
                 .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED)
+                .build();
+    }
+    @Bean
+    public LambdaClient lambdaClient() {
+        return LambdaClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(awsAccessKey, awsSecretKey)))
                 .build();
     }
 }

--- a/src/main/java/com/swyp8team2/image/util/FileValidator.java
+++ b/src/main/java/com/swyp8team2/image/util/FileValidator.java
@@ -36,8 +36,11 @@ public class FileValidator {
         }
 
         String originalFilename = file.getOriginalFilename();
+        if (originalFilename.length() > 100) {
+            throw new BadRequestException(ErrorCode.FILE_NAME_TOO_LONG);
+        }
+
         String ext = Optional.of(originalFilename)
-                .filter(name -> name.contains("."))
                 .map(name -> name.substring(name.lastIndexOf('.') + 1))
                 .orElseThrow(() -> new BadRequestException(ErrorCode.MISSING_FILE_EXTENSION))
                 .toLowerCase();

--- a/src/main/java/com/swyp8team2/image/util/FileValidator.java
+++ b/src/main/java/com/swyp8team2/image/util/FileValidator.java
@@ -41,6 +41,7 @@ public class FileValidator {
         }
 
         String ext = Optional.of(originalFilename)
+                .filter(name -> name.contains("."))
                 .map(name -> name.substring(name.lastIndexOf('.') + 1))
                 .orElseThrow(() -> new BadRequestException(ErrorCode.MISSING_FILE_EXTENSION))
                 .toLowerCase();

--- a/src/test/java/com/swyp8team2/image/util/FileValidatorTest.java
+++ b/src/test/java/com/swyp8team2/image/util/FileValidatorTest.java
@@ -20,13 +20,13 @@ class FileValidatorTest {
 
     @BeforeEach
     void setUp() {
-        String allowedExtensions = "gif,jpg,jpeg,png";
+        String allowedExtensions = "gif,jpg,jpeg,png,webp,heic,heif";
         fileValidator = new FileValidator(allowedExtensions);
     }
 
     @Test
     @DisplayName("파일 유효성 체크 - 파일 크기 초과")
-    void validate_validFile_shouldPass() {
+    void validate_exceedMaxFileSize() {
         // given
         byte[] largeContent = new byte[(int) (MAX_FILE_SIZE + 1)];
         MockMultipartFile file = new MockMultipartFile(
@@ -44,7 +44,7 @@ class FileValidatorTest {
 
     @Test
     @DisplayName("파일 유효성 체크 - 지원하지 않는 확장자")
-    void validate_unsupportedExtension_shouldThrowException() {
+    void validate_unsupportedFileExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
                 "file",
@@ -60,13 +60,31 @@ class FileValidatorTest {
     }
 
     @Test
+    @DisplayName("파일 유효성 체크 - 파일명 너무 김")
+    void validate_fileNameTooLong() {
+        // given
+        String filename = new String(new char[101])+".jpeg";
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                filename,
+                "",
+                "dummy content".getBytes(StandardCharsets.UTF_8)
+        );
+
+        // when then
+        assertThatThrownBy(() -> fileValidator.validate(file))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(ErrorCode.FILE_NAME_TOO_LONG.getMessage());
+    }
+
+    @Test
     @DisplayName("파일 유효성 체크 - 확장자 누락")
-    void validate_missingFileExtension_shouldThrowException() {
+    void validate_missingFileExtension() {
         // given
         MockMultipartFile file = new MockMultipartFile(
                 "file",
                 "test",
-                "",
+                "text/plain",
                 "dummy content".getBytes(StandardCharsets.UTF_8)
         );
 
@@ -78,7 +96,7 @@ class FileValidatorTest {
 
     @Test
     @DisplayName("파일 유효성 체크 - 여러 파일 중 하나가 유효성 실패")
-    void validate_multipleFiles_oneInvalid_shouldThrowException() {
+    void validate_multipleFilesOneInvalid() {
         // given
         MockMultipartFile file1 = new MockMultipartFile(
                 "file",


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 리사이징 함수 제거
- 람다 호출 추가
- webP 확장자 외에 jpeg 확장자 통일
- 기타 로직 수정

## 📢 그 외
- twelvemonkeys 의존성을 통해 webp 플러그인을 추가하여 기존 ImageIO에서 webP 파일 읽기
- Validator에 파일명 유효성 체크하도록 변경
- webP 파일 쓰기 호환 문제로 우선 jpeg로 통일하되 webP 파일은 그대로 업로드
- heic, heif 파일 읽기는 자바에서 호환이 되지 않아서 람다(NodeJs)에서 변환 후 업로드 처리

## ★ 후속 작업
- 프론트 측에서 resize 경로 삭제 처리되면 RequestDto 및 엔티티 수정 필요

## 📌 관련 이슈
#47 