### PR TITLE
투표 단일/복수, 삭제 기능 추가

### DIFF
--- a/src/docs/asciidoc/votes.adoc
+++ b/src/docs/asciidoc/votes.adoc
@@ -5,3 +5,8 @@
 === `POST` 투표
 
 operation::vote-controller-test/vote[snippets='http-request,curl-request,request-headers,request-fields,http-response']
+
+[[투표-취소]]
+=== `DELETE` 투표 취소
+
+operation::vote-controller-test/cancel-vote[snippets='http-request,curl-request,path-parameters,request-headers,http-response']

--- a/src/main/java/com/swyp8team2/common/config/SecurityConfig.java
+++ b/src/main/java/com/swyp8team2/common/config/SecurityConfig.java
@@ -117,6 +117,7 @@ public class SecurityConfig {
         MvcRequestMatcher.Builder mvc = new MvcRequestMatcher.Builder(introspect);
         return new MvcRequestMatcher[]{
                 mvc.pattern(HttpMethod.POST, "/posts/{postId}/votes"),
+                mvc.pattern(HttpMethod.DELETE, "/votes/{voteId}"),
                 mvc.pattern(HttpMethod.GET, "/users/me"),
         };
     }

--- a/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
+++ b/src/main/java/com/swyp8team2/common/dev/DataInitializer.java
@@ -11,17 +11,15 @@ import com.swyp8team2.crypto.application.CryptoService;
 import com.swyp8team2.image.domain.ImageFile;
 import com.swyp8team2.image.domain.ImageFileRepository;
 import com.swyp8team2.image.presentation.dto.ImageFileDto;
-import com.swyp8team2.post.application.PostService;
 import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostImage;
 import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.post.domain.VoteType;
 import com.swyp8team2.user.domain.NicknameAdjective;
 import com.swyp8team2.user.domain.NicknameAdjectiveRepository;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
 import com.swyp8team2.vote.application.VoteService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -84,7 +82,7 @@ public class DataInitializer {
             for (int j = 0; j < 30; j += 2) {
                 ImageFile imageFile1 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));
                 ImageFile imageFile2 = imageFileRepository.save(ImageFile.create(new ImageFileDto("202502240006030.png", "https://image.photopic.site/images-dev/202502240006030.png", "https://image.photopic.site/images-dev/resized_202502240006030.png")));
-                Post post = postRepository.save(Post.create(user.getId(), "description" + j, List.of(PostImage.create("뽀또A", imageFile1.getId()), PostImage.create("뽀또B", imageFile2.getId()))));
+                Post post = postRepository.save(Post.create(user.getId(), "description" + j, List.of(PostImage.create("뽀또A", imageFile1.getId()), PostImage.create("뽀또B", imageFile2.getId())), VoteType.SINGLE));
                 post.setShareUrl(shaereUrlCryptoService.encrypt(String.valueOf(post.getId())));
                 posts.add(post);
             }

--- a/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
+++ b/src/main/java/com/swyp8team2/common/exception/ErrorCode.java
@@ -23,6 +23,8 @@ public enum ErrorCode {
     FILE_NAME_TOO_LONG("파일 이름이 너무 김"),
     ACCESS_DENIED_VOTE_STATUS("투표 현황 조회 권한 없음"),
     COMMENT_NOT_FOUND("존재하지 않는 댓글"),
+    VOTE_NOT_FOUND("존재하지 않는 투표"),
+    NOT_VOTER("투표자가 아님"),
 
     //401
     EXPIRED_TOKEN("토큰 만료"),

--- a/src/main/java/com/swyp8team2/post/application/PostService.java
+++ b/src/main/java/com/swyp8team2/post/application/PostService.java
@@ -59,7 +59,7 @@ public class PostService {
     @Transactional
     public CreatePostResponse create(Long userId, CreatePostRequest request) {
         List<PostImage> postImages = createPostImages(request);
-        Post post = Post.create(userId, request.description(), postImages);
+        Post post = Post.create(userId, request.description(), postImages, request.voteType());
         Post save = postRepository.save(post);
         save.setShareUrl(shareUrlCryptoService.encrypt(String.valueOf(save.getId())));
         return new CreatePostResponse(save.getId(), save.getShareUrl());

--- a/src/main/java/com/swyp8team2/post/domain/Post.java
+++ b/src/main/java/com/swyp8team2/post/domain/Post.java
@@ -47,7 +47,18 @@ public class Post extends BaseEntity {
 
     private String shareUrl;
 
-    public Post(Long id, Long userId, String description, Status status, Scope scope, List<PostImage> images, String shareUrl) {
+    private VoteType voteType;
+
+    public Post(
+            Long id,
+            Long userId,
+            String description,
+            Status status,
+            Scope scope,
+            List<PostImage> images,
+            String shareUrl,
+            VoteType voteType
+    ) {
         validateDescription(description);
         validatePostImages(images);
         this.id = id;
@@ -58,6 +69,7 @@ public class Post extends BaseEntity {
         this.images = images;
         images.forEach(image -> image.setPost(this));
         this.shareUrl = shareUrl;
+        this.voteType = voteType;
     }
 
     private void validatePostImages(List<PostImage> images) {
@@ -72,8 +84,8 @@ public class Post extends BaseEntity {
         }
     }
 
-    public static Post create(Long userId, String description, List<PostImage> images) {
-        return new Post(null, userId, description, Status.PROGRESS, Scope.PRIVATE, images, null);
+    public static Post create(Long userId, String description, List<PostImage> images, VoteType voteType) {
+        return new Post(null, userId, description, Status.PROGRESS, Scope.PRIVATE, images, null, voteType);
     }
 
     public PostImage getBestPickedImage() {

--- a/src/main/java/com/swyp8team2/post/domain/VoteType.java
+++ b/src/main/java/com/swyp8team2/post/domain/VoteType.java
@@ -1,0 +1,5 @@
+package com.swyp8team2.post.domain;
+
+public enum VoteType {
+    SINGLE, MULTIPLE
+}

--- a/src/main/java/com/swyp8team2/post/presentation/PostController.java
+++ b/src/main/java/com/swyp8team2/post/presentation/PostController.java
@@ -33,7 +33,6 @@ public class PostController {
             @Valid @RequestBody CreatePostRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-
         return ResponseEntity.ok(postService.create(userInfo.userId(), request));
     }
 

--- a/src/main/java/com/swyp8team2/post/presentation/dto/CreatePostRequest.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/CreatePostRequest.java
@@ -1,5 +1,6 @@
 package com.swyp8team2.post.presentation.dto;
 
+import com.swyp8team2.post.domain.VoteType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
@@ -10,6 +11,9 @@ public record CreatePostRequest(
         String description,
 
         @Valid @NotNull
-        List<PostImageRequestDto> images
+        List<PostImageRequestDto> images,
+
+        @NotNull
+        VoteType voteType
 ) {
 }

--- a/src/main/java/com/swyp8team2/post/presentation/dto/PostImageResponse.java
+++ b/src/main/java/com/swyp8team2/post/presentation/dto/PostImageResponse.java
@@ -5,6 +5,6 @@ public record PostImageResponse(
         String imageName,
         String imageUrl,
         String thumbnailUrl,
-        boolean voted
+        Long voteId
 ) {
 }

--- a/src/main/java/com/swyp8team2/vote/application/VoteService.java
+++ b/src/main/java/com/swyp8team2/vote/application/VoteService.java
@@ -4,6 +4,7 @@ import com.swyp8team2.common.exception.BadRequestException;
 import com.swyp8team2.common.exception.ErrorCode;
 import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostRepository;
+import com.swyp8team2.post.domain.VoteType;
 import com.swyp8team2.user.domain.User;
 import com.swyp8team2.user.domain.UserRepository;
 import com.swyp8team2.vote.domain.Vote;
@@ -11,6 +12,8 @@ import com.swyp8team2.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,36 +26,36 @@ public class VoteService {
 
     @Transactional
     public Long vote(Long voterId, Long postId, Long imageId) {
-        User voter = userRepository.findById(voterId)
-                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
-        deleteVoteIfExisting(postId, voter.getId());
-        Vote vote = createVote(postId, imageId, voter.getId());
-        return vote.getId();
-    }
-
-    private void deleteVoteIfExisting(Long postId, Long userId) {
-        voteRepository.findByUserIdAndPostId(userId, postId)
-                        .ifPresent(vote -> {
-                            voteRepository.delete(vote);
-                            postRepository.findById(postId)
-                                    .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND))
-                                    .cancelVote(vote.getPostImageId());
-                        });
-    }
-
-    private Vote createVote(Long postId, Long imageId, Long userId) {
+        Optional<Vote> existsVote = voteRepository.findByUserIdAndPostImageId(voterId, imageId);
+        if (existsVote.isPresent()) {
+            return existsVote.get().getId();
+        }
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND));
         post.validateProgress();
+
+        User voter = userRepository.findById(voterId)
+                .orElseThrow(() -> new BadRequestException(ErrorCode.USER_NOT_FOUND));
+
+        VoteType voteType = post.getVoteType();
+        if (VoteType.SINGLE.equals(voteType)) {
+            deleteVoteIfExisting(post, voter.getId());
+        }
+        Vote vote = createVote(post, imageId, voter.getId());
+        return vote.getId();
+    }
+
+    private void deleteVoteIfExisting(Post post, Long userId) {
+        voteRepository.findByUserIdAndPostId(userId, post.getId())
+                        .ifPresent(vote -> {
+                            voteRepository.delete(vote);
+                            post.cancelVote(vote.getPostImageId());
+                        });
+    }
+
+    private Vote createVote(Post post, Long imageId, Long userId) {
         Vote vote = voteRepository.save(Vote.of(post.getId(), imageId, userId));
         post.vote(imageId);
         return vote;
-    }
-
-    @Transactional
-    public Long guestVote(Long userId, Long postId, Long imageId) {
-        deleteVoteIfExisting(postId, userId);
-        Vote vote = createVote(postId, imageId, userId);
-        return vote.getId();
     }
 }

--- a/src/main/java/com/swyp8team2/vote/domain/Vote.java
+++ b/src/main/java/com/swyp8team2/vote/domain/Vote.java
@@ -36,4 +36,8 @@ public class Vote extends BaseEntity {
     public static Vote of(Long postId, Long postImageId, Long userId) {
         return new Vote(null, postId, postImageId, userId);
     }
+
+    public boolean isVoter(Long userId) {
+        return this.userId.equals(userId);
+    }
 }

--- a/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
+++ b/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
@@ -11,4 +11,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     Optional<Vote> findByUserIdAndPostId(Long userId, Long postId);
 
     Slice<Vote> findByUserId(Long userId);
+
+    Optional<Vote> findByUserIdAndPostImageId(Long voterId, Long imageId);
 }

--- a/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
+++ b/src/main/java/com/swyp8team2/vote/domain/VoteRepository.java
@@ -13,4 +13,6 @@ public interface VoteRepository extends JpaRepository<Vote, Long> {
     Slice<Vote> findByUserId(Long userId);
 
     Optional<Vote> findByUserIdAndPostImageId(Long voterId, Long imageId);
+
+    Optional<Vote> findByIdAndUserId(Long voteId, Long userId);
 }

--- a/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
+++ b/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,12 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/posts/{postId}/votes")
 public class VoteController {
 
     private final VoteService voteService;
 
-    @PostMapping("")
+    @PostMapping("/posts/{postId}/votes")
     public ResponseEntity<Void> vote(
             @PathVariable("postId") Long postId,
             @Valid @RequestBody VoteRequest request,
@@ -34,13 +34,12 @@ public class VoteController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/guest")
-    public ResponseEntity<Void> guestVote(
-            @PathVariable("postId") Long postId,
-            @Valid @RequestBody VoteRequest request,
+    @DeleteMapping("/votes/{voteId}")
+    public ResponseEntity<Void> cancelVote(
+            @PathVariable("voteId") Long voteId,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        voteService.vote(userInfo.userId(), postId, request.imageId());
+        voteService.cancelVote(userInfo.userId(), voteId);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
+++ b/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
@@ -40,7 +40,7 @@ public class VoteController {
             @Valid @RequestBody VoteRequest request,
             @AuthenticationPrincipal UserInfo userInfo
     ) {
-        voteService.guestVote(userInfo.userId(), postId, request.imageId());
+        voteService.vote(userInfo.userId(), postId, request.imageId());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
+++ b/src/main/java/com/swyp8team2/vote/presentation/VoteController.java
@@ -43,22 +43,4 @@ public class VoteController {
         voteService.guestVote(userInfo.userId(), postId, request.imageId());
         return ResponseEntity.ok().build();
     }
-
-    @PatchMapping("")
-    public ResponseEntity<Void> changeVote(
-            @PathVariable("postId") Long postId,
-            @Valid @RequestBody ChangeVoteRequest request,
-            @AuthenticationPrincipal UserInfo userInfo
-    ) {
-        return ResponseEntity.ok().build();
-    }
-
-    @PatchMapping("/guest")
-    public ResponseEntity<Void> changeGuestVote(
-            @PathVariable("postId") Long postId,
-            @RequestHeader(CustomHeader.GUEST_TOKEN) String guestId,
-            @Valid @RequestBody ChangeVoteRequest request
-    ) {
-        return ResponseEntity.ok().build();
-    }
 }

--- a/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
+++ b/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
@@ -10,6 +10,7 @@ import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostImage;
 import com.swyp8team2.post.domain.PostRepository;
 import com.swyp8team2.post.domain.Status;
+import com.swyp8team2.post.domain.VoteType;
 import com.swyp8team2.post.presentation.dto.CreatePostRequest;
 import com.swyp8team2.post.presentation.dto.CreatePostResponse;
 import com.swyp8team2.post.presentation.dto.PostResponse;
@@ -67,10 +68,14 @@ class PostServiceTest extends IntegrationTest {
     void create() throws Exception {
         //given
         long userId = 1L;
-        CreatePostRequest request = new CreatePostRequest("description", List.of(
-                new PostImageRequestDto(1L),
-                new PostImageRequestDto(2L)
-        ));
+        CreatePostRequest request = new CreatePostRequest(
+                "description",
+                List.of(
+                        new PostImageRequestDto(1L),
+                        new PostImageRequestDto(2L)
+                ),
+                VoteType.SINGLE
+        );
         String shareUrl = "shareUrl";
         given(shareUrlCryptoService.encrypt(any()))
                 .willReturn(shareUrl);
@@ -85,6 +90,8 @@ class PostServiceTest extends IntegrationTest {
                 () -> assertThat(post.getDescription()).isEqualTo("description"),
                 () -> assertThat(post.getUserId()).isEqualTo(userId),
                 () -> assertThat(post.getShareUrl()).isEqualTo(shareUrl),
+                () -> assertThat(post.getStatus()).isEqualTo(Status.PROGRESS),
+                () -> assertThat(post.getVoteType()).isEqualTo(VoteType.SINGLE),
                 () -> assertThat(images).hasSize(2),
                 () -> assertThat(images.get(0).getImageFileId()).isEqualTo(1L),
                 () -> assertThat(images.get(0).getName()).isEqualTo("뽀또A"),
@@ -100,10 +107,13 @@ class PostServiceTest extends IntegrationTest {
     void create_invalidPostImageCount() throws Exception {
         //given
         long userId = 1L;
-        CreatePostRequest request = new CreatePostRequest("description", List.of(
-                new PostImageRequestDto(1L)
-        ));
-
+        CreatePostRequest request = new CreatePostRequest(
+                "description",
+                List.of(
+                        new PostImageRequestDto(1L)
+                ),
+                VoteType.SINGLE
+        );
         //when then
         assertThatThrownBy(() -> postService.create(userId, request))
                 .isInstanceOf(BadRequestException.class)
@@ -115,10 +125,14 @@ class PostServiceTest extends IntegrationTest {
     void create_descriptionCountExceeded() throws Exception {
         //given
         long userId = 1L;
-        CreatePostRequest request = new CreatePostRequest("a".repeat(101), List.of(
-                new PostImageRequestDto(1L),
-                new PostImageRequestDto(2L)
-        ));
+        CreatePostRequest request = new CreatePostRequest(
+                "a".repeat(101),
+                List.of(
+                        new PostImageRequestDto(1L),
+                        new PostImageRequestDto(2L)
+                ),
+                VoteType.SINGLE
+        );
 
         //when then
         assertThatThrownBy(() -> postService.create(userId, request))

--- a/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
+++ b/src/test/java/com/swyp8team2/post/application/PostServiceTest.java
@@ -162,9 +162,9 @@ class PostServiceTest extends IntegrationTest {
                 () -> assertThat(response.shareUrl()).isEqualTo(post.getShareUrl()),
                 () -> assertThat(votes).hasSize(2),
                 () -> assertThat(votes.get(0).imageUrl()).isEqualTo(imageFile1.getImageUrl()),
-                () -> assertThat(votes.get(0).voted()).isFalse(),
+                () -> assertThat(votes.get(0).voteId()).isNull(),
                 () -> assertThat(votes.get(1).imageUrl()).isEqualTo(imageFile2.getImageUrl()),
-                () -> assertThat(votes.get(1).voted()).isFalse()
+                () -> assertThat(votes.get(1).voteId()).isNull()
         );
     }
 

--- a/src/test/java/com/swyp8team2/post/domain/PostTest.java
+++ b/src/test/java/com/swyp8team2/post/domain/PostTest.java
@@ -25,7 +25,7 @@ class PostTest {
         );
 
         //when
-        Post post = Post.create(userId, description, postImages);
+        Post post = Post.create(userId, description, postImages, VoteType.SINGLE);
 
         //then
         List<PostImage> images = post.getImages();
@@ -52,7 +52,7 @@ class PostTest {
         );
 
         //when then
-        assertThatThrownBy(() -> Post.create(1L, "description", postImages))
+        assertThatThrownBy(() -> Post.create(1L, "description", postImages, VoteType.SINGLE))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.INVALID_POST_IMAGE_COUNT.getMessage());
     }
@@ -68,7 +68,7 @@ class PostTest {
         );
 
         //when then
-        assertThatThrownBy(() -> Post.create(1L, description, postImages))
+        assertThatThrownBy(() -> Post.create(1L, description, postImages, VoteType.SINGLE))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED.getMessage());
     }
@@ -82,7 +82,7 @@ class PostTest {
                 PostImage.create("뽀또A", 1L),
                 PostImage.create("뽀또B", 2L)
         );
-        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl");
+        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl", VoteType.SINGLE);
 
         //when
         post.close(userId);
@@ -100,7 +100,7 @@ class PostTest {
                 PostImage.create("뽀또A", 1L),
                 PostImage.create("뽀또B", 2L)
         );
-        Post post = new Post(null, userId, "description", Status.CLOSED, Scope.PRIVATE, postImages, "shareUrl");
+        Post post = new Post(null, userId, "description", Status.CLOSED, Scope.PRIVATE, postImages, "shareUrl", VoteType.SINGLE);
 
         //when then
         assertThatThrownBy(() -> post.close(userId))
@@ -117,7 +117,7 @@ class PostTest {
                 PostImage.create("뽀또A", 1L),
                 PostImage.create("뽀또B", 2L)
         );
-        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl");
+        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl", VoteType.SINGLE);
 
         //when then
         assertThatThrownBy(() -> post.close(2L))
@@ -134,7 +134,7 @@ class PostTest {
                 PostImage.create("뽀또A", 1L),
                 PostImage.create("뽀또B", 2L)
         );
-        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl");
+        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl", VoteType.SINGLE);
 
         //when then
         post.toggleScope(userId);
@@ -154,7 +154,7 @@ class PostTest {
                 PostImage.create("뽀또A", 1L),
                 PostImage.create("뽀또B", 2L)
         );
-        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl");
+        Post post = new Post(null, userId, "description", Status.PROGRESS, Scope.PRIVATE, postImages, "shareUrl", VoteType.SINGLE);
 
         //when then
         assertThatThrownBy(() -> post.toggleScope(2L))

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -3,6 +3,7 @@ package com.swyp8team2.post.presentation;
 import com.swyp8team2.auth.domain.UserInfo;
 import com.swyp8team2.common.dto.CursorBasePaginatedResponse;
 import com.swyp8team2.post.domain.Status;
+import com.swyp8team2.post.domain.VoteType;
 import com.swyp8team2.post.presentation.dto.*;
 import com.swyp8team2.support.RestDocsTest;
 import com.swyp8team2.support.WithMockUserInfo;
@@ -43,7 +44,8 @@ class PostControllerTest extends RestDocsTest {
         //given
         CreatePostRequest request = new CreatePostRequest(
                 "제목",
-                List.of(new PostImageRequestDto(1L), new PostImageRequestDto(2L))
+                List.of(new PostImageRequestDto(1L), new PostImageRequestDto(2L)),
+                VoteType.SINGLE
         );
         CreatePostResponse response = new CreatePostResponse(1L, "shareUrl");
         given(postService.create(any(), any()))
@@ -69,7 +71,10 @@ class PostControllerTest extends RestDocsTest {
                                         .attributes(constraints("최소 2개")),
                                 fieldWithPath("images[].imageFileId")
                                         .type(JsonFieldType.NUMBER)
-                                        .description("투표 후보 이미지 ID")
+                                        .description("투표 후보 이미지 ID"),
+                                fieldWithPath("voteType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("투표 방식 (SINGLE, MULTIPLE)")
                         ),
                         responseFields(
                                 fieldWithPath("postId")

--- a/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
+++ b/src/test/java/com/swyp8team2/post/presentation/PostControllerTest.java
@@ -101,8 +101,8 @@ class PostControllerTest extends RestDocsTest {
                 ),
                 "description",
                 List.of(
-                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1", true),
-                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/2", false)
+                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1", 1L),
+                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/2", null)
                 ),
                 "https://photopic.site/shareurl",
                  true,
@@ -132,7 +132,7 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("images[].imageName").type(JsonFieldType.STRING).description("사진 이름"),
                                 fieldWithPath("images[].imageUrl").type(JsonFieldType.STRING).description("사진 이미지"),
                                 fieldWithPath("images[].thumbnailUrl").type(JsonFieldType.STRING).description("확대 사진 이미지"),
-                                fieldWithPath("images[].voted").type(JsonFieldType.BOOLEAN).description("투표 여부"),
+                                fieldWithPath("images[].voteId").type(JsonFieldType.NUMBER).optional().description("투표 Id (투표 안 한 경우 null)"),
                                 fieldWithPath("shareUrl").type(JsonFieldType.STRING).description("게시글 공유 URL"),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 시간"),
                                 fieldWithPath("status").type(JsonFieldType.STRING).description("게시글 마감 여부 (PROGRESS, CLOSED)"),
@@ -155,8 +155,8 @@ class PostControllerTest extends RestDocsTest {
                 ),
                 "description",
                 List.of(
-                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1", true),
-                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/2", false)
+                        new PostImageResponse(1L, "뽀또A", "https://image.photopic.site/image/1", "https://image.photopic.site/image/resize/1", 1L),
+                        new PostImageResponse(2L, "뽀또B", "https://image.photopic.site/image/2", "https://image.photopic.site/image/resize/2", null)
                 ),
                 "https://photopic.site/shareurl",
                 true,
@@ -186,7 +186,7 @@ class PostControllerTest extends RestDocsTest {
                                 fieldWithPath("images[].imageName").type(JsonFieldType.STRING).description("사진 이름"),
                                 fieldWithPath("images[].imageUrl").type(JsonFieldType.STRING).description("사진 이미지"),
                                 fieldWithPath("images[].thumbnailUrl").type(JsonFieldType.STRING).description("확대 사진 이미지"),
-                                fieldWithPath("images[].voted").type(JsonFieldType.BOOLEAN).description("투표 여부"),
+                                fieldWithPath("images[].voteId").type(JsonFieldType.NUMBER).optional().description("투표 Id (투표 안 한 경우 null)"),
                                 fieldWithPath("shareUrl").type(JsonFieldType.STRING).description("게시글 공유 URL"),
                                 fieldWithPath("createdAt").type(JsonFieldType.STRING).description("게시글 생성 시간"),
                                 fieldWithPath("status").type(JsonFieldType.STRING).description("게시글 마감 여부 (PROGRESS, CLOSED)"),

--- a/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
+++ b/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
@@ -19,7 +19,20 @@ public abstract class FixtureGenerator {
                         PostImage.create("뽀또A", imageFile1.getId()),
                         PostImage.create("뽀또B", imageFile2.getId())
                 ),
-                VoteType.SINGLE);
+                VoteType.SINGLE
+        );
+    }
+
+    public static Post createMultiplePost(Long userId, ImageFile imageFile1, ImageFile imageFile2, int key) {
+        return Post.create(
+                userId,
+                "description" + key,
+                List.of(
+                        PostImage.create("뽀또A", imageFile1.getId()),
+                        PostImage.create("뽀또B", imageFile2.getId())
+                ),
+                VoteType.MULTIPLE
+        );
     }
 
     public static User createUser(int key) {

--- a/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
+++ b/src/test/java/com/swyp8team2/support/fixture/FixtureGenerator.java
@@ -4,6 +4,7 @@ import com.swyp8team2.image.domain.ImageFile;
 import com.swyp8team2.image.presentation.dto.ImageFileDto;
 import com.swyp8team2.post.domain.Post;
 import com.swyp8team2.post.domain.PostImage;
+import com.swyp8team2.post.domain.VoteType;
 import com.swyp8team2.user.domain.User;
 
 import java.util.List;
@@ -17,8 +18,8 @@ public abstract class FixtureGenerator {
                 List.of(
                         PostImage.create("뽀또A", imageFile1.getId()),
                         PostImage.create("뽀또B", imageFile2.getId())
-                )
-        );
+                ),
+                VoteType.SINGLE);
     }
 
     public static User createUser(int key) {

--- a/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
+++ b/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
@@ -96,17 +96,18 @@ class VoteServiceTest extends IntegrationTest {
         ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
         ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
         Post post = postRepository.save(new Post(
-                        null,
-                        user.getId(),
-                        "description",
-                        Status.CLOSED,
-                        Scope.PRIVATE,
-                        List.of(
-                                PostImage.create("뽀또A", imageFile1.getId()),
-                                PostImage.create("뽀또B", imageFile2.getId())
-                        ),
-                        "shareUrl"
-                ));
+                null,
+                user.getId(),
+                "description",
+                Status.CLOSED,
+                Scope.PRIVATE,
+                List.of(
+                        PostImage.create("뽀또A", imageFile1.getId()),
+                        PostImage.create("뽀또B", imageFile2.getId())
+                ),
+                "shareUrl",
+                VoteType.SINGLE
+        ));
 
         // when
         assertThatThrownBy(() -> voteService.vote(user.getId(), post.getId(), post.getImages().get(0).getId()))
@@ -182,7 +183,8 @@ class VoteServiceTest extends IntegrationTest {
                         PostImage.create("뽀또A", imageFile1.getId()),
                         PostImage.create("뽀또B", imageFile2.getId())
                 ),
-                "shareUrl"
+                "shareUrl",
+                VoteType.SINGLE
         ));
 
         // when

--- a/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
+++ b/src/test/java/com/swyp8team2/vote/application/VoteServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static com.swyp8team2.support.fixture.FixtureGenerator.createImageFile;
+import static com.swyp8team2.support.fixture.FixtureGenerator.createMultiplePost;
 import static com.swyp8team2.support.fixture.FixtureGenerator.createPost;
 import static com.swyp8team2.support.fixture.FixtureGenerator.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,8 +42,8 @@ class VoteServiceTest extends IntegrationTest {
     ImageFileRepository imageFileRepository;
 
     @Test
-    @DisplayName("투표하기")
-    void vote() {
+    @DisplayName("단일 투표하기")
+    void singleVote() {
         // given
         User user = userRepository.save(createUser(1));
         ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
@@ -64,10 +65,10 @@ class VoteServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("투표하기 - 다른 이미지로 투표 변경한 경우")
-    void vote_change() {
+    @DisplayName("단일 투표하기 - 다른 이미지로 투표 변경한 경우")
+    void singleVote_change() {
         // given
-        User user = userRepository.save(createUser(1));
+        User user = userRepository.save(createUser(2));
         ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
         ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
         Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
@@ -84,6 +85,37 @@ class VoteServiceTest extends IntegrationTest {
                 () -> assertThat(vote.getPostId()).isEqualTo(post.getId()),
                 () -> assertThat(vote.getPostImageId()).isEqualTo(post.getImages().get(1).getId()),
                 () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(0),
+                () -> assertThat(findPost.getImages().get(1).getVoteCount()).isEqualTo(1)
+        );
+    }
+
+    @Test
+    @DisplayName("복수 투표하기")
+    void multipleVote() {
+        // given
+        User user = userRepository.save(createUser(1));
+        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
+        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
+        Post post = postRepository.save(createMultiplePost(user.getId(), imageFile1, imageFile2, 1));
+
+        // when
+        Long voteId1 = voteService.vote(user.getId(), post.getId(), post.getImages().get(0).getId());
+        Long voteId2 = voteService.vote(user.getId(), post.getId(), post.getImages().get(1).getId());
+
+        // then
+        Vote vote1 = voteRepository.findById(voteId1).get();
+        Vote vote2 = voteRepository.findById(voteId2).get();
+        Post findPost = postRepository.findById(post.getId()).get();
+        assertAll(
+                () -> assertThat(vote1.getUserId()).isEqualTo(user.getId()),
+                () -> assertThat(vote1.getPostId()).isEqualTo(post.getId()),
+                () -> assertThat(vote1.getPostImageId()).isEqualTo(post.getImages().get(0).getId()),
+
+                () -> assertThat(vote2.getUserId()).isEqualTo(user.getId()),
+                () -> assertThat(vote2.getPostId()).isEqualTo(post.getId()),
+                () -> assertThat(vote2.getPostImageId()).isEqualTo(post.getImages().get(1).getId()),
+
+                () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(1),
                 () -> assertThat(findPost.getImages().get(1).getVoteCount()).isEqualTo(1)
         );
     }
@@ -111,84 +143,6 @@ class VoteServiceTest extends IntegrationTest {
 
         // when
         assertThatThrownBy(() -> voteService.vote(user.getId(), post.getId(), post.getImages().get(0).getId()))
-                .isInstanceOf(BadRequestException.class)
-                .hasMessage(ErrorCode.POST_ALREADY_CLOSED.getMessage());
-    }
-
-    @Test
-    @DisplayName("게스트 투표하기")
-    void guestVote() {
-        // given
-        User user = userRepository.save(createUser(1));
-        Long guestId = user.getId() + 1L;
-        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
-        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
-        Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
-
-        // when
-        Long voteId = voteService.guestVote(guestId, post.getId(), post.getImages().get(0).getId());
-
-        // then
-        Vote vote = voteRepository.findById(voteId).get();
-        Post findPost = postRepository.findById(post.getId()).get();
-        assertAll(
-                () -> assertThat(vote.getUserId()).isEqualTo(guestId),
-                () -> assertThat(vote.getPostId()).isEqualTo(post.getId()),
-                () -> assertThat(vote.getPostImageId()).isEqualTo(post.getImages().get(0).getId()),
-                () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(1)
-        );
-    }
-
-    @Test
-    @DisplayName("게스트 투표하기 - 다른 이미지로 투표 변경한 경우")
-    void guestVote_change() {
-        // given
-        User user = userRepository.save(createUser(1));
-        Long guestId = user.getId() + 1L;
-        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
-        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
-        Post post = postRepository.save(createPost(user.getId(), imageFile1, imageFile2, 1));
-        voteService.guestVote(guestId, post.getId(), post.getImages().get(0).getId());
-
-        // when
-        Long voteId = voteService.guestVote(guestId, post.getId(), post.getImages().get(1).getId());
-
-        // then
-        Vote vote = voteRepository.findById(voteId).get();
-        Post findPost = postRepository.findById(post.getId()).get();
-        assertAll(
-                () -> assertThat(vote.getUserId()).isEqualTo(guestId),
-                () -> assertThat(vote.getPostId()).isEqualTo(post.getId()),
-                () -> assertThat(vote.getPostImageId()).isEqualTo(post.getImages().get(1).getId()),
-                () -> assertThat(findPost.getImages().get(0).getVoteCount()).isEqualTo(0),
-                () -> assertThat(findPost.getImages().get(1).getVoteCount()).isEqualTo(1)
-        );
-    }
-
-    @Test
-    @DisplayName("게스트 투표하기 - 투표 마감된 경우")
-    void guestVote_alreadyClosed() {
-        // given
-        User user = userRepository.save(createUser(1));
-        Long guestId = user.getId() + 1L;
-        ImageFile imageFile1 = imageFileRepository.save(createImageFile(1));
-        ImageFile imageFile2 = imageFileRepository.save(createImageFile(2));
-        Post post = postRepository.save(new Post(
-                null,
-                user.getId(),
-                "description",
-                Status.CLOSED,
-                Scope.PRIVATE,
-                List.of(
-                        PostImage.create("뽀또A", imageFile1.getId()),
-                        PostImage.create("뽀또B", imageFile2.getId())
-                ),
-                "shareUrl",
-                VoteType.SINGLE
-        ));
-
-        // when
-        assertThatThrownBy(() -> voteService.guestVote(guestId, post.getId(), post.getImages().get(0).getId()))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(ErrorCode.POST_ALREADY_CLOSED.getMessage());
     }

--- a/src/test/java/com/swyp8team2/vote/presentation/VoteControllerTest.java
+++ b/src/test/java/com/swyp8team2/vote/presentation/VoteControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -54,81 +55,21 @@ class VoteControllerTest extends RestDocsTest {
     }
 
     @Test
-    @WithMockUserInfo(role = Role.GUEST)
-    @DisplayName("게스트 투표")
-    void guestVote() throws Exception {
+    @WithMockUserInfo
+    @DisplayName("투표 취소")
+    void cancelVote() throws Exception {
         //given
-        VoteRequest request = new VoteRequest(1L);
 
         //when test
-        mockMvc.perform(post("/posts/{postId}/votes/guest", "1")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-                        .header(CustomHeader.GUEST_TOKEN, "guestToken"))
-                .andExpect(status().isOk())
-                .andDo(restDocs.document(
-                        requestHeaders(guestHeader()),
-                        pathParameters(
-                                parameterWithName("postId").description("게시글 Id")
-                        ),
-                        requestFields(
-                                fieldWithPath("imageId")
-                                        .type(JsonFieldType.NUMBER)
-                                        .description("투표 후보 Id")
-                        )
-                ));
-        verify(voteService, times(1)).vote(any(), any(), any());
-    }
-
-    @Test
-    @WithMockUserInfo
-    @DisplayName("투표 변경")
-    void changeVote() throws Exception {
-        //given
-        ChangeVoteRequest request = new ChangeVoteRequest(1L);
-
-        //when
-        mockMvc.perform(patch("/posts/{postId}/votes", "1")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
+        mockMvc.perform(delete("/votes/{voteId}", "1")
                         .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
                         requestHeaders(authorizationHeader()),
                         pathParameters(
-                                parameterWithName("postId").description("변경할 게시글 Id")
-                        ),
-                        requestFields(
-                                fieldWithPath("imageId")
-                                        .type(JsonFieldType.NUMBER)
-                                        .description("변경할 투표 이미지 Id")
+                                parameterWithName("voteId").description("투표 Id")
                         )
                 ));
-    }
-
-    @Test
-    @WithMockUserInfo(role = Role.GUEST)
-    @DisplayName("게스트 투표 변경")
-    void guestChangeVote() throws Exception {
-        //given
-        ChangeVoteRequest request = new ChangeVoteRequest(1L);
-
-        //when
-        mockMvc.perform(patch("/posts/{postId}/votes/guest", "1")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-                        .header(CustomHeader.GUEST_TOKEN, "guestToken"))
-                .andExpect(status().isOk())
-                .andDo(restDocs.document(
-                        requestHeaders(guestHeader()),
-                        pathParameters(
-                                parameterWithName("postId").description("변경활 게시글 Id")
-                        ),
-                        requestFields(
-                                fieldWithPath("imageId")
-                                        .type(JsonFieldType.NUMBER)
-                                        .description("변경할 투표 이미지 Id")
-                        )
-                ));
+        verify(voteService, times(1)).cancelVote(any(), any());
     }
 }

--- a/src/test/java/com/swyp8team2/vote/presentation/VoteControllerTest.java
+++ b/src/test/java/com/swyp8team2/vote/presentation/VoteControllerTest.java
@@ -77,7 +77,7 @@ class VoteControllerTest extends RestDocsTest {
                                         .description("투표 후보 Id")
                         )
                 ));
-        verify(voteService, times(1)).guestVote(any(), any(), any());
+        verify(voteService, times(1)).vote(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 🚀 작업 내용 설명

- 게시글 생성 시 투표 방식 필드 추가
- 단일/복수 투표 기능 추가
- 투표 삭제 기능 추가
- 게시글 상세 조회 투표 여부 필드 voted: boolean -> voteId: number (optional) 로 변경

## 📢 그 외

voted -> voteId로 변경한 이유는 투표 삭제할 때 api url에 voteId를 사용하기 위함입니다.

이번 pr이랑 별개로 저번에 영학님 게시글 scope 관련 pr 올리신거 리뷰에서 놓친게 있는데 게시글 생성 할 때 공개/비공개 필드 추가하는 부분이 빠진 것 같아요

## 📌 관련 이슈
