### PR TITLE
fix: 닉네임 조회 실패 시 고정 닉네임으로 생성

### DIFF
--- a/src/main/java/com/swyp8team2/user/application/NicknameGenerator.java
+++ b/src/main/java/com/swyp8team2/user/application/NicknameGenerator.java
@@ -15,6 +15,6 @@ public class NicknameGenerator {
         long randomIndex = (long)(Math.random() * 500);
         return nicknameAdjectiveRepository.findNicknameAdjectiveById(randomIndex)
                 .map(adjective -> adjective.getAdjective() + " " + role.getNickname())
-                .orElse("user_" + System.currentTimeMillis());
+                .orElse("숨겨진 " + role.getNickname());
     }
 }

--- a/src/main/java/com/swyp8team2/user/application/NicknameGenerator.java
+++ b/src/main/java/com/swyp8team2/user/application/NicknameGenerator.java
@@ -12,8 +12,7 @@ public class NicknameGenerator {
     private final NicknameAdjectiveRepository nicknameAdjectiveRepository;
 
     public String generate(Role role) {
-        long randomIndex = (long)(Math.random() * 500);
-        return nicknameAdjectiveRepository.findNicknameAdjectiveById(randomIndex)
+        return nicknameAdjectiveRepository.findRandomNicknameAdjective()
                 .map(adjective -> adjective.getAdjective() + " " + role.getNickname())
                 .orElse("숨겨진 " + role.getNickname());
     }

--- a/src/main/java/com/swyp8team2/user/domain/NicknameAdjectiveRepository.java
+++ b/src/main/java/com/swyp8team2/user/domain/NicknameAdjectiveRepository.java
@@ -1,6 +1,7 @@
 package com.swyp8team2.user.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -8,5 +9,12 @@ import java.util.Optional;
 @Repository
 public interface NicknameAdjectiveRepository extends JpaRepository<NicknameAdjective, Long> {
 
-    Optional<NicknameAdjective> findNicknameAdjectiveById(Long id);
+    @Query("""
+            SELECT na
+            FROM NicknameAdjective na
+            ORDER BY RAND()
+            LIMIT 1
+            """
+    )
+    Optional<NicknameAdjective> findRandomNicknameAdjective();
 }

--- a/src/test/java/com/swyp8team2/user/application/NicknameGeneratorTest.java
+++ b/src/test/java/com/swyp8team2/user/application/NicknameGeneratorTest.java
@@ -32,7 +32,7 @@ class NicknameGeneratorTest {
     void generate() throws Exception {
         //given
         Role role = Role.USER;
-        given(nicknameAdjectiveRepository.findNicknameAdjectiveById(any()))
+        given(nicknameAdjectiveRepository.findRandomNicknameAdjective())
                 .willReturn(Optional.of(new NicknameAdjective("호기심 많은")));
 
         //when
@@ -47,7 +47,7 @@ class NicknameGeneratorTest {
     void generate_guest() throws Exception {
         //given
         Role role = Role.GUEST;
-        given(nicknameAdjectiveRepository.findNicknameAdjectiveById(any()))
+        given(nicknameAdjectiveRepository.findRandomNicknameAdjective())
                 .willReturn(Optional.of(new NicknameAdjective("호기심 많은")));
 
         //when


### PR DESCRIPTION
## 🚀 작업 내용 설명
- 디폴트 닉네임은 "숨겨진 뽀또" or "숨겨진 낫또" 로 설정

## 📢 그 외
- 서버 로그나 디비 로그나 이렇다할만한 문제가 식별이 안되는데 소스만 봤을 때는 디비 조회를 못해서 발생한 문제로 보입니다.
  해당 시점의 SQL 로그를 볼 수 있으면 좋겠지만 서버 로그에 같이 있으면 다시 내용 보는데 불편할 것 같고
  SQL 로그만 분리해서 관리하는 방안으로 추가하면 좋을 것 같기도 합니다.
- 우선 timestamp로 생성되는것만 막긴 했는데 다른 방안 있으면 피드백 부탁드립니다

## 📌 관련 이슈
#128 