### PR TITLE
투표 동시성 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
+
+    //test
+    testImplementation 'org.springframework.boot:spring-boot-docker-compose'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -6,8 +6,6 @@
 
 operation::auth-controller-test/kakao-o-auth-sign-in[snippets='http-request,curl-request,request-fields,http-response,response-cookies,response-fields']
 
-[[게스트-로그인]]
-=== `POST` 게스트 로그인
 
 ```
 1. 리프레시 토큰이 있는 경우

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,7 +11,7 @@ api문서
 == 개요
 
 ```
-뽀또픽 API 문서입니다.
+츄즈 API 문서입니다.
 잘못되었거나 추가 및 수정되어야 할 내용이 있으면 언제든지 연락주세요.
 ```
 
@@ -68,10 +68,7 @@ Authorization: Bearer accessToken
 
 ```
 user1
-eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc0MTA2MTc2NSwiaXNzIjoic3d5cDh0ZWFtMiIsImV4cCI6MzMyNzcwNjE3NjV9.3o2uNN3IuGZ-uLrAPdkHBBHF9kk9KALlP373eF27HI4
-
-user2
-eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc0MTA2MjkxMiwiaXNzIjoic3d5cDh0ZWFtMiIsImV4cCI6MzMyNzcwNjI5MTJ9.eC4oUp9ROb6udMarevZQcImTWojcL_3kkY1YgatpuJg
+eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEiLCJyb2xlIjoiVVNFUiIsImlhdCI6MTc1MDA1ODc3OCwiaXNzIjoiY2hvb3otZGV2IiwiZXhwIjozMzI4NjA1ODc3OH0.STIaA5vs9g_zbaO5X7rj3zcnEqo1NLl6Iw_N5pcCeyc
 ```
 
 [[인증-예외]]

--- a/src/main/java/com/chooz/common/config/CorsConfig.java
+++ b/src/main/java/com/chooz/common/config/CorsConfig.java
@@ -22,7 +22,7 @@ public class CorsConfig {
     }
 
     @Bean
-    @Profile({"local", "dev", "default", "test"})
+    @Profile("!prod")
     public UrlBasedCorsConfigurationSource corsConfigurationSourceLocal() {
         CorsConfiguration configuration = getCorsConfiguration();
         configuration.setAllowedOrigins(List.of("http://localhost:5173", "https://dev.chooz.site", "https://www.dev.photopic.site"));

--- a/src/main/java/com/chooz/common/dev/DataInitConfig.java
+++ b/src/main/java/com/chooz/common/dev/DataInitConfig.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Profile({"!prod", "!test"})
+@Profile("dev")
 @Component
 @RequiredArgsConstructor
 public class DataInitConfig {

--- a/src/main/java/com/chooz/common/dev/DataInitConfig.java
+++ b/src/main/java/com/chooz/common/dev/DataInitConfig.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Profile({"dev", "local"})
+@Profile({"!prod", "!test"})
 @Component
 @RequiredArgsConstructor
 public class DataInitConfig {

--- a/src/main/java/com/chooz/common/dev/DataInitializer.java
+++ b/src/main/java/com/chooz/common/dev/DataInitializer.java
@@ -1,22 +1,16 @@
 package com.chooz.common.dev;
 
-import com.chooz.auth.application.jwt.JwtClaim;
 import com.chooz.auth.application.jwt.JwtService;
-import com.chooz.auth.application.jwt.TokenPair;
-import com.chooz.auth.presentation.dto.TokenResponse;
-import com.chooz.comment.domain.Comment;
 import com.chooz.comment.domain.CommentRepository;
-import com.chooz.image.presentation.dto.ImageFileDto;
 import com.chooz.post.domain.CloseOption;
 import com.chooz.post.domain.CloseType;
 import com.chooz.post.domain.CommentActive;
+import com.chooz.post.domain.PollChoice;
 import com.chooz.post.domain.PollOption;
 import com.chooz.post.domain.PollType;
 import com.chooz.post.domain.Post;
-import com.chooz.post.domain.PollChoice;
 import com.chooz.post.domain.PostRepository;
 import com.chooz.post.domain.Scope;
-import com.chooz.user.domain.NicknameAdjective;
 import com.chooz.user.domain.NicknameAdjectiveRepository;
 import com.chooz.user.domain.User;
 import com.chooz.user.domain.UserRepository;
@@ -25,11 +19,9 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
-@Profile({"dev", "local"})
+@Profile({"!prod", "!test"})
 @Component
 public class DataInitializer {
 
@@ -59,12 +51,17 @@ public class DataInitializer {
 
     @Transactional
     public void init() {
-//        if (userRepository.count() > 0) {
-//            return;
-//        }
-//        List<NicknameAdjective> adjectives = nicknameAdjectiveRepository.findAll();
-//        User testUser = userRepository.save(User.create("nickname", "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
-        User user = userRepository.save(User.create("chooz", "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
+        User user = userRepository.save(User.create("chooz1", "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
+        User user2 = userRepository.save(User.create("chooz2", "https://t1.kakaocdn.net/account_images/default_profile.jpeg"));
+        postRepository.save(Post.create(
+                user.getId(),
+                "title",
+                "description",
+                "imageUrl",
+                List.of(PollChoice.create("title1", "imageUrl1"), PollChoice.create("title1", "imageUrl1")),
+                "shareUrl",
+                PollOption.create(PollType.SINGLE, Scope.PUBLIC, CommentActive.OPEN),
+                CloseOption.create(CloseType.VOTER, null, 2)));
 //        TokenResponse tokenResponse = jwtService.createToken(new JwtClaim(testUser.getId(), testUser.getRole()));
 //        TokenPair tokenPair = tokenResponse.tokenPair();
 //        System.out.println("accessToken = " + tokenPair.accessToken());

--- a/src/main/java/com/chooz/post/application/PostVotedEventListener.java
+++ b/src/main/java/com/chooz/post/application/PostVotedEventListener.java
@@ -8,10 +8,10 @@ import com.chooz.vote.application.VotedEvent;
 import com.chooz.vote.domain.VoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -24,10 +24,12 @@ public class PostVotedEventListener {
     public void handle(VotedEvent event) {
         Post post = postRepository.findById(event.postId())
                 .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND));
-        if (!post.isCloseTypeVoter()) {
-            return;
-        }
-        long voterCount = voteRepository.countVoterByPostId(event.postId());
+
+        handleClosePost(post);
+    }
+
+    private void handleClosePost(Post post) {
+        long voterCount = voteRepository.countVoterByPostId(post.getId());
         if (post.isClosableByVoterCount(voterCount)) {
             post.close();
         }

--- a/src/main/java/com/chooz/post/domain/Post.java
+++ b/src/main/java/com/chooz/post/domain/Post.java
@@ -60,7 +60,7 @@ public class Post extends BaseEntity {
 
     @Embedded
     private PollOption pollOption;
-    
+
     @Embedded
     private CloseOption closeOption;
 
@@ -129,7 +129,7 @@ public class Post extends BaseEntity {
             throw new BadRequestException(ErrorCode.DESCRIPTION_LENGTH_EXCEEDED);
         }
     }
-    
+
     private static void validateTitle(String title) {
         if (StringUtils.hasText(title) && title.length() > 50) {
             throw new BadRequestException(ErrorCode.TITLE_LENGTH_EXCEEDED);
@@ -183,15 +183,19 @@ public class Post extends BaseEntity {
         return PollType.SINGLE.equals(pollOption.getPollType());
     }
 
-    public boolean isCloseTypeVoter() {
-        return CloseType.VOTER.equals(closeOption.getCloseType());
+    public boolean isClosableByVoterCount(long voterCount) {
+        if (!isCloseTypeVoter()) {
+            return false;
+        }
+        return closeOption.getMaxVoterCount() == voterCount;
     }
 
-    public boolean isClosableByVoterCount(long voterCount) {
-        return closeOption.getMaxVoterCount() == voterCount;
+    private boolean isCloseTypeVoter() {
+        return CloseType.VOTER.equals(closeOption.getCloseType());
     }
 
     public boolean isClosed() {
         return this.status.equals(Status.CLOSED);
     }
+
 }

--- a/src/main/java/com/chooz/post/domain/PostRepository.java
+++ b/src/main/java/com/chooz/post/domain/PostRepository.java
@@ -56,7 +56,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     )
     Optional<Post> findByIdFetchPollChoicesWithLock(@Param("postId") Long postId);
 
-
     @Query(""" 
             SELECT new com.chooz.post.presentation.dto.FeedDto(
                     p.id,

--- a/src/main/java/com/chooz/post/domain/PostRepository.java
+++ b/src/main/java/com/chooz/post/domain/PostRepository.java
@@ -2,9 +2,11 @@ package com.chooz.post.domain;
 
 import com.chooz.post.application.dto.PostWithVoteCount;
 import com.chooz.post.presentation.dto.FeedDto;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -43,6 +45,17 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             """
     )
     Optional<Post> findByIdFetchPollChoices(@Param("postId") Long postId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p
+            FROM Post p
+            JOIN FETCH p.pollChoices
+            WHERE p.id = :postId
+            """
+    )
+    Optional<Post> findByIdFetchPollChoicesWithLock(@Param("postId") Long postId);
+
 
     @Query(""" 
             SELECT new com.chooz.post.presentation.dto.FeedDto(

--- a/src/main/java/com/chooz/vote/application/VoteService.java
+++ b/src/main/java/com/chooz/vote/application/VoteService.java
@@ -28,7 +28,7 @@ public class VoteService {
 
     @Transactional
     public List<Long> vote(Long voterId, Long postId, List<Long> pollChoiceIds) {
-        Post post = postRepository.findByIdFetchPollChoices(postId)
+        Post post = postRepository.findByIdFetchPollChoicesWithLock(postId)
                 .orElseThrow(() -> new BadRequestException(ErrorCode.POST_NOT_FOUND));
 
         voteValidator.validateIsVotable(post, pollChoiceIds);

--- a/src/main/java/com/chooz/vote/domain/VoteRepository.java
+++ b/src/main/java/com/chooz/vote/domain/VoteRepository.java
@@ -1,28 +1,19 @@
 package com.chooz.vote.domain;
 
-import com.chooz.post.application.dto.MostVotedPollChoice;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface VoteRepository extends JpaRepository<Vote, Long> {
     List<Vote> findByUserIdAndPostId(Long userId, Long postId);
 
-    Slice<Vote> findByUserId(Long userId);
-
-    Optional<Vote> findByUserIdAndPollChoiceId(Long voterId, Long pollChoiceId);
-
     List<Vote> findAllByPostId(Long postId);
 
     List<Vote> findByPostIdAndDeletedFalse(Long id);
-
-    List<Vote> findAllByPostIdIn(List<Long> postIds);
 
     @Query("""
             SELECT COUNT(DISTINCT v.userId)

--- a/src/test/compose.yaml
+++ b/src/test/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  mysql:
+    image: 'mysql:latest'
+    environment:
+      - 'MYSQL_DATABASE=chooz'
+      - 'MYSQL_PASSWORD=secret'
+      - 'MYSQL_ROOT_PASSWORD=verysecret'
+      - 'MYSQL_USER=chooz'
+    ports:
+      - '3306:3306'

--- a/src/test/java/com/chooz/support/IntegrationTest.java
+++ b/src/test/java/com/chooz/support/IntegrationTest.java
@@ -2,7 +2,10 @@ package com.chooz.support;
 
 import jakarta.transaction.Transactional;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @Transactional
 @SpringBootTest
 public abstract class IntegrationTest {

--- a/src/test/java/com/chooz/support/fixture/PostFixture.java
+++ b/src/test/java/com/chooz/support/fixture/PostFixture.java
@@ -61,6 +61,12 @@ public class PostFixture {
         return new CloseOption(CloseType.DATE, LocalDateTime.now().minusMinutes(5), null);
     }
 
+    public static CloseOption voterCloseOption(int maxVoterCount) {
+        return new CloseOption(CloseType.VOTER, null, maxVoterCount);
+    }
+
+    public static final CloseOption SELF_CREATE_OPTION = new CloseOption(CloseType.SELF, null, null);
+
     public static PollOption.PollOptionBuilder createPollOptionBuilder() {
         return PollOption.builder()
                 .pollType(PollType.SINGLE)

--- a/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
+++ b/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
@@ -1,0 +1,91 @@
+package com.chooz.vote.application;
+
+import com.chooz.post.domain.Post;
+import com.chooz.post.domain.PostRepository;
+import com.chooz.support.fixture.PostFixture;
+import com.chooz.support.fixture.UserFixture;
+import com.chooz.user.domain.User;
+import com.chooz.user.domain.UserRepository;
+import com.chooz.vote.domain.Vote;
+import com.chooz.vote.domain.VoteRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("mysql")
+@SpringBootTest
+class VoteConcurrentTest {
+
+    @Autowired
+    VoteService voteService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    VoteRepository voteRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @AfterEach
+    void setUp() {
+//        voteRepository.deleteAll();
+//        postRepository.deleteAll();
+//        userRepository.deleteAll();
+    }
+
+    @Test
+//    @Disabled
+    void concurrentTest() throws Exception {
+        // given
+        int maxVoterCount = 4;
+        User user = userRepository.save(UserFixture.createDefaultUser());
+        Post post = postRepository.save(PostFixture.createPostBuilder()
+                        .userId(user.getId())
+                        .closeOption(PostFixture.voterCloseOption(maxVoterCount))
+                        .build());
+        Long pollChoiceId = post.getPollChoices().getFirst().getId();
+
+        int threadCount = 30;
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            users.add(userRepository.save(UserFixture.createDefaultUser()));
+        }
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            executorService.submit(() -> {
+                try {
+                    Long voterId = users.get(index).getId();
+
+                    voteService.vote(voterId, post.getId(), List.of(pollChoiceId));
+                } catch (Exception e) {
+                    System.out.println("예외 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        // then
+        List<Vote> voteList = voteRepository.findAllByPostId(post.getId());
+        assertThat(voteList).hasSize(maxVoterCount);
+    }
+}

--- a/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
+++ b/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
@@ -48,7 +48,7 @@ class VoteConcurrentTest {
     }
 
     @Test
-//    @Disabled
+    @Disabled
     void concurrentTest() throws Exception {
         // given
         int maxVoterCount = 4;

--- a/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
+++ b/src/test/java/com/chooz/vote/application/VoteConcurrentTest.java
@@ -42,9 +42,9 @@ class VoteConcurrentTest {
 
     @AfterEach
     void setUp() {
-//        voteRepository.deleteAll();
-//        postRepository.deleteAll();
-//        userRepository.deleteAll();
+        voteRepository.deleteAll();
+        postRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/test/java/com/chooz/vote/application/VoteValidatorTest.java
+++ b/src/test/java/com/chooz/vote/application/VoteValidatorTest.java
@@ -2,8 +2,12 @@ package com.chooz.vote.application;
 
 import com.chooz.common.exception.BadRequestException;
 import com.chooz.common.exception.ErrorCode;
-import com.chooz.post.domain.*;
+import com.chooz.post.domain.CloseType;
+import com.chooz.post.domain.PollType;
+import com.chooz.post.domain.Post;
+import com.chooz.post.domain.Status;
 import com.chooz.support.fixture.PostFixture;
+import com.chooz.vote.domain.Vote;
 import com.chooz.vote.domain.VoteRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,12 +17,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
@@ -149,23 +152,12 @@ class VoteValidatorTest {
     }
 
     @Test
-    @DisplayName("validatePollChoiceId - 빈 선택지 리스트일 경우 검증 통과")
-    void validatePollChoiceId_emptyList() {
-        // given
-        Post post = PostFixture.createDefaultPost(1L);
-        List<Long> emptyPollChoiceIds = List.of(); // 빈 선택지 리스트
-
-        // when & then
-        assertDoesNotThrow(() -> voteValidator.validateIsVotable(post, emptyPollChoiceIds));
-    }
-
-    @Test
     @DisplayName("validateVoteStatusAccess - 작성자가 아니고 투표하지 않은 사용자는 투표 현황 조회 불가")
     void validateVoteStatusAccess_notAuthorAndNotVoter() {
         // given
         Long userId = 999L;
         Post post = PostFixture.createDefaultPost(1L); // 작성자 ID: 1L
-        List<com.chooz.vote.domain.Vote> votes = new ArrayList<>();
+        List<Vote> votes = new ArrayList<>();
 
         // when & then
         assertThatThrownBy(() -> voteValidator.validateVoteStatusAccess(userId, post, votes))

--- a/src/test/java/com/chooz/vote/domain/VoteRepositoryTest.java
+++ b/src/test/java/com/chooz/vote/domain/VoteRepositoryTest.java
@@ -9,11 +9,9 @@ import com.chooz.support.fixture.UserFixture;
 import com.chooz.support.fixture.VoteFixture;
 import com.chooz.user.domain.User;
 import com.chooz.user.domain.UserRepository;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.parameters.P;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,7 +27,6 @@ class VoteRepositoryTest extends RepositoryTest {
     UserRepository userRepository;
 
     @Test
-    @Disabled
     @DisplayName("단일 투표 참여자 수 조회")
     void countVoterByPostId_single() throws Exception {
         //given
@@ -49,7 +46,6 @@ class VoteRepositoryTest extends RepositoryTest {
     }
 
     @Test
-    @Disabled
     @DisplayName("단일 투표 참여자 수 조회")
     void countVoterByPostId_multiple() throws Exception {
         //given

--- a/src/test/java/com/chooz/vote/domain/VoteRepositoryTest.java
+++ b/src/test/java/com/chooz/vote/domain/VoteRepositoryTest.java
@@ -9,6 +9,7 @@ import com.chooz.support.fixture.UserFixture;
 import com.chooz.support.fixture.VoteFixture;
 import com.chooz.user.domain.User;
 import com.chooz.user.domain.UserRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,7 @@ class VoteRepositoryTest extends RepositoryTest {
     UserRepository userRepository;
 
     @Test
+    @Disabled
     @DisplayName("단일 투표 참여자 수 조회")
     void countVoterByPostId_single() throws Exception {
         //given
@@ -47,6 +49,7 @@ class VoteRepositoryTest extends RepositoryTest {
     }
 
     @Test
+    @Disabled
     @DisplayName("단일 투표 참여자 수 조회")
     void countVoterByPostId_multiple() throws Exception {
         //given


### PR DESCRIPTION
## 🚀 작업 내용 설명

참여자 수 마감일 경우 동시성 문제 해결
- Post 테이블에 voterCount 컬럼 추가 x
  - 하나의 API에서 투표 생성, 수정, 취소를 같이 진행하고 있기 때문에 상황에 따른 voterCount 증가 감소 유지를 구분하기 힘들기 때문
- 비관적 락 사용
  - 낙관적 락의 경우 Post 테이블에 voterCount가 없기 때문에 동시에 서로 다른 트랜잭션에서 Post를 읽은 경우에 Vote 생성 여부와 상관없이 Post의 Version이 바뀌지 않기 때문에 동시성 해결이 안 됨

## 📢 그 외

- prod 테스트용 테스트 환경 docker compose 추가
- 동시성 테스트 시간 오래 걸려서 disabled 처리

## 📌 관련 이슈
